### PR TITLE
git: ignore google generated creds from ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /calyptia
+gha-creds-*.json
 
 # Created by https://www.toptal.com/developers/gitignore/api/go,linux,macos,windows,visualstudiocode,vim,emacs,dotenv
 # Edit at https://www.toptal.com/developers/gitignore?templates=go,linux,macos,windows,visualstudiocode,vim,emacs,dotenv


### PR DESCRIPTION
# Summary of this proposal

Getting:

```
git is currently in a dirty state
Please check in your pipeline what can be changing the following files:
?? gha-creds-8248dd7a92d546ae.json
```

right now. Here is an explanation of what is happening https://goreleaser.com/errors/dirty/
This PR just adds the file to `.gitignore`.

## Notes for the reviewer

<!-- Provide any notes that might be important for the (reviewer) of changes -->

## Issue(s) number(s)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
*Disclaimer: Please do not create a Pull Request without creating an issue first.*

## Checklist for submitter

- [ ] My PR has a related issue/bug number.
- [ ] My PR provides tests
  - [ ] Integration tests are added/passes
  - [ ] Unit tests are added/passes
  - [ ] End-to-end tests added/passes
  - [ ] Static code check added/passes
  - [ ] Linting on documentation added/passes
  - [ ] Does not affect code coverage stats
- [ ] My PR requires updating dependencies
- [ ] My PR has the documentation changes required.

## Checklist for reviewer

- [ ] The proposal fixes a bug/issue or implements a new feature that is well described.
- [ ] The proposal has sufficient test cases that covers the changes.
  - [ ] If changes an API, it does not break backwards compatibility (-1 major version).
- [ ] If integration is required, the proposal has integration tests.
- [ ] The proposal does not break coverage stats
- [ ] The proposal has the required documentation changes.

## Backport

<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backport to the current or earlier releases then please submit
a PR for that particular branch.
-->

- [ ] Backport to the latest stable release.