### PR TITLE
Add --show-metadata to get core_instances.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace github.com/calyptia/cli/k8s => ./k8s
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
-	github.com/calyptia/api v0.3.7
+	github.com/calyptia/api v0.3.9
 	github.com/calyptia/cli/k8s v0.0.0-00010101000000-000000000000
 	github.com/calyptia/go-bubble-table v0.2.1
 	github.com/charmbracelet/bubbletea v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
-github.com/calyptia/api v0.3.7 h1:FHh9Lp9jO99Fw7gf1lGecJKEuIQ/ZBCEF74UNlAZtfw=
-github.com/calyptia/api v0.3.7/go.mod h1:tMRIWoW2NIqylo8pYEoOFgRW1axmEE9Yd6SXBEdSHLQ=
+github.com/calyptia/api v0.3.9 h1:UVWTyNUAuFs8BX5f4aLahocuhniObUCcmZAzgg+k+mg=
+github.com/calyptia/api v0.3.9/go.mod h1:tMRIWoW2NIqylo8pYEoOFgRW1axmEE9Yd6SXBEdSHLQ=
 github.com/calyptia/go-bubble-table v0.2.1 h1:NWcVRyGCLuP7QIA29uUFSY+IjmWcmUWHjy5J/CPb0Rk=
 github.com/calyptia/go-bubble-table v0.2.1/go.mod h1:gJvzUOUzfQeA9JmgLumyJYWJMtuRQ7WxxTwc9tjEiGw=
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=


### PR DESCRIPTION
# Summary of this proposal

- Adds the --show-metadata parameter.
- Will filter out empty or zeroed variables.

Fixes #83

## Notes for the reviewer

```
➜ cli (show-metadata) ✔ ./calyptia get core_instances --cloud-url http://localhost:5000  --show-metadata
NAME          VERSION  ENVIRONMENT PIPELINES TAGS STATUS      AGE     METADATA
core-instance v0.1-dev default     1              unreachable 6 hours {"k8s.cluster_platform":"linux/arm64","k8s.cluster_version":"1.21.1","k8s.namespace":"default"}

➜ cli (show-metadata) ✔ ./calyptia get core_instances --cloud-url http://localhost:5000                 
NAME          VERSION  ENVIRONMENT PIPELINES TAGS STATUS      AGE
core-instance v0.1-dev default     1              unreachable 6 hours

➜ cli (show-metadata) ✔ 

```


## Issue(s) number(s)

#83 

