### PR TITLE
 Enable debug logging for AWS create/delete operations.

### DIFF
--- a/aws/client.go
+++ b/aws/client.go
@@ -116,8 +116,12 @@ func (i *CreatedInstance) String() string {
 	return fmt.Sprintf("instance-id: %s, instance-type: %s, privateIPv4: %s", i.EC2InstanceID, i.EC2InstanceType, i.PrivateIPv4)
 }
 
-func New(ctx context.Context, prefix, region, credentials, profileFile, profileName string) (*DefaultClient, error) {
+func New(ctx context.Context, prefix, region, credentials, profileFile, profileName string, debug bool) (*DefaultClient, error) {
 	var opts []func(options *awsconfig.LoadOptions) error
+
+	if debug {
+		opts = append(opts, awsconfig.WithClientLogMode(aws.LogSigning|aws.LogRequestWithBody|aws.LogResponseWithBody))
+	}
 
 	if region != "" {
 		opts = append(opts, awsconfig.WithRegion(region))

--- a/cmd/calyptia/create_core_instance_aws.go
+++ b/cmd/calyptia/create_core_instance_aws.go
@@ -94,6 +94,7 @@ func newCmdCreateCoreInstanceOnAWS(config *config, client awsclient.Client, poll
 		tags                   []string
 		noHealthCheckPipeline  bool
 		noElasticIPv4Address   bool
+		debug                  bool
 		coreInstanceVersion    string
 		coreInstanceName       string
 		environment            string
@@ -122,7 +123,7 @@ func newCmdCreateCoreInstanceOnAWS(config *config, client awsclient.Client, poll
 			ctx := context.Background()
 
 			if client == nil {
-				client, err = awsclient.New(ctx, coreInstanceName, region, credentials, profileFile, profileName)
+				client, err = awsclient.New(ctx, coreInstanceName, region, credentials, profileFile, profileName, debug)
 				if err != nil {
 					return fmt.Errorf("could not initialize client: %w", err)
 				}
@@ -219,6 +220,7 @@ func newCmdCreateCoreInstanceOnAWS(config *config, client awsclient.Client, poll
 	fs.StringVar(&securityGroupName, "security-group", "", "AWS Security group name to use.")
 	fs.StringVar(&subnetID, "subnet-id", "", "AWS subnet name to use.If you don't specify a subnet ID, we choose a default subnet from your default VPC for you. If you don't have a default VPC, you MUST specify a subnet.")
 	fs.BoolVar(&noElasticIPv4Address, "no-elastic-ip", false, "Don't allocate a floating ip address for the instance.")
+	fs.BoolVar(&debug, "debug", false, "Enable debug logging")
 	fs.StringVar(&elasticIPv4Address, "elastic-ip", "", "IPv4 formatted address of an existing elastic ip address allocation to associate to this instance. If not provided, a new one will be allocated for the created VM.")
 	fs.StringVar(&elasticIPv4AddressPool, "elastic-ip-address-pool", "", "IP address pool to allocate the elastic ip address from.")
 

--- a/cmd/calyptia/delete_core_instance_aws.go
+++ b/cmd/calyptia/delete_core_instance_aws.go
@@ -13,6 +13,7 @@ import (
 
 func newCmdDeleteCoreInstanceOnAWS(config *config, client awsclient.Client) *cobra.Command {
 	var (
+		debug       bool
 		credentials string
 		region      string
 		profileFile string
@@ -50,7 +51,7 @@ func newCmdDeleteCoreInstanceOnAWS(config *config, client awsclient.Client) *cob
 
 			ctx := context.Background()
 			if client == nil {
-				client, err = awsclient.New(ctx, coreInstanceName, region, credentials, profileFile, profileName)
+				client, err = awsclient.New(ctx, coreInstanceName, region, credentials, profileFile, profileName, false)
 				if err != nil {
 					return fmt.Errorf("could not initialize AWS client: %w", err)
 				}
@@ -119,6 +120,7 @@ func newCmdDeleteCoreInstanceOnAWS(config *config, client awsclient.Client) *cob
 	fs.StringVar(&environment, "environment", "default", "Calyptia environment name")
 	fs.BoolVar(&skipError, "skip-error", false, "Skip errors during delete process")
 	fs.BoolVar(&confirmDelete, "yes", isNonInteractiveMode, "Confirm deletion")
+	fs.BoolVar(&debug, "debug", false, "Enable debug logging")
 
 	_ = cmd.RegisterFlagCompletionFunc("environment", config.completeEnvironments)
 


### PR DESCRIPTION
# Summary of this proposal

Enable debug logging for AWS create/delete operations.

Signed-off-by: Jorge Niedbalski <j@calyptia.com>
