### PR TITLE
Add on configs github token needed by test images

### DIFF
--- a/aws/client.go
+++ b/aws/client.go
@@ -37,6 +37,9 @@ CALYPTIA_CORE_INSTANCE_TAGS={{.CoreInstanceTags}}
 {{if .CoreInstanceEnvironment }}
 CALYPTIA_CORE_INSTANCE_ENVIRONMENT={{.CoreInstanceEnvironment}}
 {{end}}
+{{if .CoreInstanceGitHubToken }}
+GITHUB_TOKEN={{.CoreInstanceGitHubToken}}
+{{end}}
 `
 	instanceUpCheckTimeout = 10 * time.Minute
 	instanceUpCheckBackOff = 5 * time.Second
@@ -90,6 +93,7 @@ type (
 		CoreInstanceName        string
 		CoreInstanceTags        string
 		CoreInstanceEnvironment string
+		CoreInstanceGitHubToken string
 	}
 
 	ElasticIPAddressParams struct {

--- a/gcp/config.go
+++ b/gcp/config.go
@@ -246,3 +246,15 @@ func (c *Config) loadKey(path string) (string, error) {
 	}
 	return string(file), nil
 }
+
+func (c *Config) SetGitHubToken(token string) *Config {
+	if token == "" {
+		return c
+	}
+
+	c.Resources[0].Properties.Metadata.Items = append(c.Resources[0].Properties.Metadata.Items, item{
+		Key:   "GITHUB_TOKEN",
+		Value: token,
+	})
+	return c
+}


### PR DESCRIPTION
# Summary of this proposal

To use Google Cloud test images we need to inform the GITHUB_TOKEN on the creation, this PR enables it by allow the user pass this param thought the `CALYPTIA_GITHUB_TOKEN` environemnt, besides removes the flag `uses-test-image` from the cli user, and add the `CALYPTIA_TEST_IMAGE_ENABLE` making it not "cleary exposed" exposed to the user, once that just the develoment team will use it on e2e tests.

Reason behind this pr is that its was being showed to the user test flags, and it was needing anther flag for the github token, what doesnt make sense outside of dev team context, thats why we r moving it to env variables, to hide it from the user


## Notes for the reviewer

<!-- Provide any notes that might be important for the (reviewer) of changes -->

## Issue(s) number(s)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
*Disclaimer: Please do not create a Pull Request without creating an issue first.*

## Checklist for submitter

- [ ] My PR has a related issue/bug number.
- [ ] My PR provides tests
  - [ ] Integration tests are added/passes
  - [ ] Unit tests are added/passes
  - [ ] End-to-end tests added/passes
  - [ ] Static code check added/passes
  - [ ] Linting on documentation added/passes
  - [ ] Does not affect code coverage stats
- [ ] My PR requires updating dependencies
- [ ] My PR has the documentation changes required.

## Checklist for reviewer

- [ ] The proposal fixes a bug/issue or implements a new feature that is well described.
- [ ] The proposal has sufficient test cases that covers the changes.
  - [ ] If changes an API, it does not break backwards compatibility (-1 major version).
- [ ] If integration is required, the proposal has integration tests.
- [ ] The proposal does not break coverage stats
- [ ] The proposal has the required documentation changes.

## Backport

<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backport to the current or earlier releases then please submit
a PR for that particular branch.
-->

- [ ] Backport to the latest stable release.