### PR TITLE
Add credentials flag to gcp client

### DIFF
--- a/cmd/calyptia/create_core_instance_gcp.go
+++ b/cmd/calyptia/create_core_instance_gcp.go
@@ -32,6 +32,7 @@ func newCmdCreateCoreInstanceOnGCP(config *config, client gcp.Client) *cobra.Com
 		network               string
 		githubToken           string
 		useTestImages         bool
+		credentials           string
 	)
 	cmd := &cobra.Command{
 		Use:     "gcp",
@@ -61,7 +62,7 @@ func newCmdCreateCoreInstanceOnGCP(config *config, client gcp.Client) *cobra.Com
 			}
 
 			if client == nil {
-				client, err = gcp.New(ctx, projectID, environment)
+				client, err = gcp.New(ctx, projectID, environment, credentials)
 				if err != nil {
 					return fmt.Errorf("could not initialize GCP client: %w", err)
 				}
@@ -152,6 +153,7 @@ func newCmdCreateCoreInstanceOnGCP(config *config, client gcp.Client) *cobra.Com
 	fs.StringVar(&network, "network", "default", "GCP Network")
 	fs.StringVar(&githubToken, "github-token", os.Getenv("GITHUB_TOKEN"), "GitHub token for test purposes")
 	fs.BoolVar(&useTestImages, "use-test-images", envBool("CALYPTIA_USE_TEST_IMAGES"), "Use GCP test images instead of released channel (only for testing/development).")
+	fs.StringVar(&credentials, "credentials", os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"), "Path to GCP credentials file. (default is $GOOGLE_APPLICATION_CREDENTIALS)")
 	fs.MarkHidden("github-token")
 	fs.MarkHidden("use-test-images")
 

--- a/cmd/calyptia/delete_core_instance_gcp.go
+++ b/cmd/calyptia/delete_core_instance_gcp.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/calyptia/cli/gcp"
 
@@ -12,6 +13,7 @@ func newCmdDeleteCoreInstanceOnGCP(config *config, client gcp.Client) *cobra.Com
 	var (
 		environment string
 		projectID   string
+		credentials string
 	)
 	cmd := &cobra.Command{
 		Use:               "gcp CORE_INSTANCE",
@@ -24,7 +26,7 @@ func newCmdDeleteCoreInstanceOnGCP(config *config, client gcp.Client) *cobra.Com
 			ctx := cmd.Context()
 			if client == nil {
 				var err error
-				client, err = gcp.New(ctx, projectID, environment)
+				client, err = gcp.New(ctx, projectID, environment, credentials)
 				if err != nil {
 					return fmt.Errorf("could not initialize GCP client: %w", err)
 				}
@@ -63,5 +65,6 @@ func newCmdDeleteCoreInstanceOnGCP(config *config, client gcp.Client) *cobra.Com
 	fs := cmd.Flags()
 	fs.StringVar(&projectID, "project-id", "", "GCP project ID")
 	fs.StringVar(&environment, "environment", "default", "Calyptia environment name")
+	fs.StringVar(&credentials, "credentials", os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"), "Path to GCP credentials file. (default is $GOOGLE_APPLICATION_CREDENTIALS)")
 	return cmd
 }

--- a/gcp/client.go
+++ b/gcp/client.go
@@ -6,6 +6,7 @@ import (
 
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/deploymentmanager/v2"
+	option "google.golang.org/api/option"
 	"gopkg.in/yaml.v2"
 )
 
@@ -56,12 +57,18 @@ func (c *DefaultClient) Deploy(ctx context.Context) error {
 	return nil
 }
 
-func New(ctx context.Context, projectName string, environment string) (*DefaultClient, error) {
-	m, err := deploymentmanager.NewService(ctx)
+func New(ctx context.Context, projectName string, environment string, credentials string) (*DefaultClient, error) {
+	var authOpts []option.ClientOption
+
+	if credentials != "" {
+		authOpts = append(authOpts, option.WithCredentialsFile(credentials))
+	}
+
+	m, err := deploymentmanager.NewService(ctx, authOpts...)
 	if err != nil {
 		return nil, err
 	}
-	c, err := compute.NewService(ctx)
+	c, err := compute.NewService(ctx, authOpts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Gabriel Bussolo <gabriel@calyptia.com>

# Summary of this proposal

Google API inst behaving same way in diferent environments, like CI or machine, it should get by default in any SO the `GOOGLE_APPLICATION_CREDENTIALS ` environement with the credentiasl, so we r adding the credentials as a parameter and passing it to the client as an option, if the client have it already set on the env it will get from there, if he inform we will consider the informed one.
Client return an error case there is no credentials

order that the client api searches for the auth: https://cloud.google.com/docs/authentication/application-default-credentials#search_order

## Notes for the reviewer

<!-- Provide any notes that might be important for the (reviewer) of changes -->

## Issue(s) number(s)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
*Disclaimer: Please do not create a Pull Request without creating an issue first.*

## Checklist for submitter

- [ ] My PR has a related issue/bug number.
- [ ] My PR provides tests
  - [ ] Integration tests are added/passes
  - [ ] Unit tests are added/passes
  - [ ] End-to-end tests added/passes
  - [ ] Static code check added/passes
  - [ ] Linting on documentation added/passes
  - [ ] Does not affect code coverage stats
- [ ] My PR requires updating dependencies
- [ ] My PR has the documentation changes required.

## Checklist for reviewer

- [ ] The proposal fixes a bug/issue or implements a new feature that is well described.
- [ ] The proposal has sufficient test cases that covers the changes.
  - [ ] If changes an API, it does not break backwards compatibility (-1 major version).
- [ ] If integration is required, the proposal has integration tests.
- [ ] The proposal does not break coverage stats
- [ ] The proposal has the required documentation changes.

## Backport

<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backport to the current or earlier releases then please submit
a PR for that particular branch.
-->

- [ ] Backport to the latest stable release.