### PR TITLE
Improve the error handling for Follow Operations method on GCP

### DIFF
--- a/cmd/calyptia/create_core_instance_gcp.go
+++ b/cmd/calyptia/create_core_instance_gcp.go
@@ -104,14 +104,15 @@ func newCmdCreateCoreInstanceOnGCP(config *config, client gcp.Client) *cobra.Com
 
 			for {
 				operation, err := client.FollowOperations(ctx)
-
-				if err != nil || operation.Error != nil {
+				if err != nil {
+					cmd.PrintErr(err)
+					cmd.Println("A problem occurred while creating the instance, a rollback will be performed...")
 					err = client.Rollback(ctx)
 					if err != nil {
 						cmd.PrintErrf("an error occurred with the operation and the rollback was not successful")
 						return nil
 					}
-					cmd.PrintErrf("an error occurred with the operation %s", operation.Name)
+					cmd.Println("Rollback successful")
 					return nil
 				}
 

--- a/cmd/calyptia/delete_core_instance_gcp.go
+++ b/cmd/calyptia/delete_core_instance_gcp.go
@@ -46,8 +46,8 @@ func newCmdDeleteCoreInstanceOnGCP(config *config, client gcp.Client) *cobra.Com
 			for {
 				operation, err := client.FollowOperations(ctx)
 
-				if err != nil || operation.Error != nil {
-					cmd.PrintErrf("an error occurred with the operation %s", operation.Name)
+				if err != nil {
+					cmd.PrintErr(err)
 					return nil
 				}
 

--- a/gcp/client.go
+++ b/gcp/client.go
@@ -79,7 +79,11 @@ func New(ctx context.Context, projectName string, environment string, credential
 }
 
 func (c *DefaultClient) FollowOperations(ctx context.Context) (*deploymentmanager.Operation, error) {
-	return c.manager.Operations.Get(c.projectName, c.deploymentName).Context(ctx).Do()
+	operation, err := c.manager.Operations.Get(c.projectName, c.deploymentName).Context(ctx).Do()
+	if operation != nil && operation.Error != nil {
+		return operation, fmt.Errorf("occurred an error with the %s operation: %v", operation.Name, operation.Error.Errors)
+	}
+	return operation, err
 }
 
 func (c *DefaultClient) Rollback(ctx context.Context) error {


### PR DESCRIPTION
Signed-off-by: Gabriel Bussolo <gabriel@calyptia.com>

# Summary of this proposal

During the e2e test [i caught a mistake while evaluating errors coming back from GCP](https://github.com/calyptia/cloud-e2e/actions/runs/3096039417/jobs/5011119422#step:11:252), so this purpose improves the error handling for operations that is happening on deployment manager.

## Notes for the reviewer

<!-- Provide any notes that might be important for the (reviewer) of changes -->

## Issue(s) number(s)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
*Disclaimer: Please do not create a Pull Request without creating an issue first.*

## Checklist for submitter

- [ ] My PR has a related issue/bug number.
- [ ] My PR provides tests
  - [ ] Integration tests are added/passes
  - [ ] Unit tests are added/passes
  - [ ] End-to-end tests added/passes
  - [ ] Static code check added/passes
  - [ ] Linting on documentation added/passes
  - [ ] Does not affect code coverage stats
- [ ] My PR requires updating dependencies
- [ ] My PR has the documentation changes required.

## Checklist for reviewer

- [ ] The proposal fixes a bug/issue or implements a new feature that is well described.
- [ ] The proposal has sufficient test cases that covers the changes.
  - [ ] If changes an API, it does not break backwards compatibility (-1 major version).
- [ ] If integration is required, the proposal has integration tests.
- [ ] The proposal does not break coverage stats
- [ ] The proposal has the required documentation changes.

## Backport

<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backport to the current or earlier releases then please submit
a PR for that particular branch.
-->

- [ ] Backport to the latest stable release.