### PR TITLE
Remove (TODO) from already implemented commands and fix on latest gcp image

### DIFF
--- a/cmd/calyptia/create_core_instance.go
+++ b/cmd/calyptia/create_core_instance.go
@@ -7,7 +7,7 @@ import (
 func newCmdCreateCoreInstance(config *config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "core_instance",
-		Short: "Setup a new core instance on either Kubernetes, Amazon EC2 (TODO), or Google Compute Engine (TODO)",
+		Short: "Setup a new core instance on either Kubernetes, Amazon EC2, or Google Compute Engine",
 	}
 	cmd.AddCommand(newCmdCreateCoreInstanceOnK8s(config, nil))
 	cmd.AddCommand(newCmdCreateCoreInstanceOnAWS(config, nil, nil))

--- a/cmd/calyptia/delete_core_instance.go
+++ b/cmd/calyptia/delete_core_instance.go
@@ -16,7 +16,7 @@ func newCmdDeleteCoreInstance(config *config, testClientSet kubernetes.Interface
 	cmd := &cobra.Command{
 		Use:     "core_instance",
 		Aliases: []string{"instance", "aggregator"},
-		Short:   "Delete a core instance from either Kubernetes, Amazon EC2 (TODO), or Google Compute Engine (TODO)",
+		Short:   "Delete a core instance from either Kubernetes, Amazon EC2, or Google Compute Engine",
 	}
 	cmd.AddCommand(
 		newCmdDeleteCoreInstanceK8s(config, nil),

--- a/cmd/calyptia/delete_core_instance_aws.go
+++ b/cmd/calyptia/delete_core_instance_aws.go
@@ -27,7 +27,7 @@ func newCmdDeleteCoreInstanceOnAWS(config *config, client awsclient.Client) *cob
 	cmd := &cobra.Command{
 		Use:               "aws CORE_INSTANCE",
 		Aliases:           []string{"ec2", "amazon"},
-		Short:             "Delete a core instance from Amazon EC2 (TODO)",
+		Short:             "Delete a core instance from Amazon EC2",
 		Args:              cobra.ExactValidArgs(1),
 		ValidArgsFunction: config.completeAggregators,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/gcp/config.go
+++ b/gcp/config.go
@@ -169,7 +169,7 @@ func (c *Config) SetTags(tags []string) *Config {
 }
 
 func (c *Config) SetImage(version string) *Config {
-	if version == "" {
+	if version == "" || version == "latest" {
 		return c
 	}
 	c.Resources[0].Properties.Disks[0].InitializeParams.SourceImage = fmt.Sprintf("projects/%s/global/images/%s", c.projectID, version)


### PR DESCRIPTION
# Summary of this proposal

Remove `(TODO)` from already implemented function on `calyptia create/delete core_images` and small fix when is informed `latest` version for GCP images, `latest` is replacing the base image already defined in the `config.yaml`

## Notes for the reviewer

<!-- Provide any notes that might be important for the (reviewer) of changes -->

## Issue(s) number(s)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
*Disclaimer: Please do not create a Pull Request without creating an issue first.*

## Checklist for submitter

- [ ] My PR has a related issue/bug number.
- [ ] My PR provides tests
  - [ ] Integration tests are added/passes
  - [ ] Unit tests are added/passes
  - [ ] End-to-end tests added/passes
  - [ ] Static code check added/passes
  - [ ] Linting on documentation added/passes
  - [ ] Does not affect code coverage stats
- [ ] My PR requires updating dependencies
- [ ] My PR has the documentation changes required.

## Checklist for reviewer

- [ ] The proposal fixes a bug/issue or implements a new feature that is well described.
- [ ] The proposal has sufficient test cases that covers the changes.
  - [ ] If changes an API, it does not break backwards compatibility (-1 major version).
- [ ] If integration is required, the proposal has integration tests.
- [ ] The proposal does not break coverage stats
- [ ] The proposal has the required documentation changes.

## Backport

<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backport to the current or earlier releases then please submit
a PR for that particular branch.
-->

- [ ] Backport to the latest stable release.