### PR TITLE
Delete daemonSets by label from cluster.

### DIFF
--- a/cmd/calyptia/create_core_instance_k8s.go
+++ b/cmd/calyptia/create_core_instance_k8s.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // register GCP auth provider
 	"k8s.io/client-go/tools/clientcmd"
 
 	cloud "github.com/calyptia/api/types"

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/calyptia/go-fluentbit-config v0.4.1
 	github.com/charmbracelet/bubbletea v0.22.1
 	github.com/charmbracelet/lipgloss v0.6.0
+	github.com/go-logfmt/logfmt v0.5.1
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/joho/godotenv v1.4.0
 	github.com/matryer/moq v0.2.7
@@ -60,7 +61,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
-	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
@@ -110,7 +110,6 @@ require (
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect
 	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/time v0.0.0-20220920022843-2ce7c2934d45 // indirect
 	golang.org/x/tools v0.1.12 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220920201722-2b89144ce006 // indirect

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -108,6 +108,7 @@ func (client *Client) CreateClusterRole(ctx context.Context, agg cloud.CreatedAg
 				Resources: []string{
 					"namespaces",
 					"deployments",
+					"daemonsets",
 					"replicasets",
 					"pods",
 					"services",
@@ -216,6 +217,13 @@ func (client *Client) CreateDeployment(
 func (client *Client) DeleteDeploymentByLabel(ctx context.Context, label, ns string) error {
 	foreground := metav1.DeletePropagationForeground
 	return client.AppsV1().Deployments(ns).DeleteCollection(ctx, metav1.DeleteOptions{
+		PropagationPolicy: &foreground,
+	}, metav1.ListOptions{LabelSelector: label})
+}
+
+func (client *Client) DeleteDaemonSetByLabel(ctx context.Context, label, ns string) error {
+	foreground := metav1.DeletePropagationForeground
+	return client.AppsV1().DaemonSets(ns).DeleteCollection(ctx, metav1.DeleteOptions{
 		PropagationPolicy: &foreground,
 	}, metav1.ListOptions{LabelSelector: label})
 }


### PR DESCRIPTION
# Summary of this proposal

Adds the operation to delete daemonSets by aggregator label from the cluster.

Signed-off-by: Jorge Niedbalski <j@calyptia.com>

## Notes for the reviewer

```
➜ cli (main) ✗ ./calyptia delete core_instance k8s cluster-logging                                
Are you sure you want to delete core instance with id "a5bfe07d-be4f-4d56-a0ee-d676064a75a8" and all of its associated kubernetes resources? (y/N) y
Successfully deleted core instance with id "a5bfe07d-be4f-4d56-a0ee-d676064a75a8"
DaemonSets:
        namespace=default name=calyptia-cluster-logging-ec91
Deployments:
        namespace=default name=calyptia-cluster-logging-default-deployment
        namespace=default name=calyptia-health-check-b08c
Services:
        namespace=default name=tcp-2020-9fb2933f-735a-4ac0-8194-5b87af15dc41
Service accounts:
        namespace=default name=calyptia-cluster-logging-default-service-account
Secrets:
        namespace=default name=calyptia-cluster-logging-default-secret
Role bindings:
        namespace=cluster name=calyptia-cluster-logging-default-cluster-role-binding
Cluster roles:
        namespace=cluster name=calyptia-cluster-logging-default-cluster-role
Successfully deleted 8 kubernetes resources

```