### PR TITLE
cmd/calyptia: set default output to stdout

### DIFF
--- a/cmd/calyptia/main.go
+++ b/cmd/calyptia/main.go
@@ -74,6 +74,7 @@ func newCmd(ctx context.Context) *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
+	cmd.SetOut(os.Stdout)
 
 	fs := cmd.PersistentFlags()
 	fs.StringVar(&cloudURLStr, "cloud-url", env("CALYPTIA_CLOUD_URL", defaultCloudURLStr), "Calyptia Cloud URL")


### PR DESCRIPTION
Changing cobra default output to stdout. This fixes printing messages.

Before:

```
cmd.Printf    -> stderr
cmd.PrintErrf -> srderr
```

Now:

```
cmd.Printf    -> stdout
cmd.PrintErrf -> srderr
```

Specifically, this fixes the new Core docker-desktop extension which executes cli commands and asserts based on whether it wrote to stdout or stderr.