### PR TITLE
Enforce deletion of config maps on removal of core_instance.

### DIFF
--- a/cmd/calyptia/delete_core_instance_k8s.go
+++ b/cmd/calyptia/delete_core_instance_k8s.go
@@ -203,7 +203,7 @@ func newCmdDeleteCoreInstanceK8s(config *config, testClientSet kubernetes.Interf
 					if !skipError {
 						return err
 					} else {
-						cmd.PrintErrf("Error: could not delete config map: %w", err)
+						cmd.PrintErrf("Error: could not delete config map: %v", err)
 					}
 				}
 

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -255,6 +255,10 @@ func (client *Client) DeleteSecretByLabel(ctx context.Context, label, ns string)
 	return client.CoreV1().Secrets(ns).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: label})
 }
 
+func (client *Client) DeleteConfigMapsByLabel(ctx context.Context, label, ns string) error {
+	return client.CoreV1().ConfigMaps(ns).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: label})
+}
+
 func (client *Client) FindServicesByLabel(ctx context.Context, label, ns string) (*apiv1.ServiceList, error) {
 	return client.CoreV1().Services(ns).List(ctx, metav1.ListOptions{LabelSelector: label})
 }


### PR DESCRIPTION
# Summary of this proposal

- Client isn't forcing the removal of labeled config maps.
- Force removal of config maps when a core_instance gets deleted. Discovered in a session with @edsiper.

Signed-off-by: Jorge Niedbalski <j@calyptia.com>

## Notes for the reviewer
N/A.