### PR TITLE
Rename aggregator parameter to core_instance.

### DIFF
--- a/cmd/calyptia/create_ingest_check.go
+++ b/cmd/calyptia/create_ingest_check.go
@@ -46,7 +46,7 @@ func newCmdCreateIngestCheck(config *config) *cobra.Command {
 					return err
 				}
 			}
-			coreInstanceID, err := config.loadAggregatorID(coreInstance, environmentID)
+			coreInstanceID, err := config.loadCoreInstanceID(coreInstance, environmentID)
 			if err != nil {
 				return err
 			}

--- a/cmd/calyptia/create_pipeline.go
+++ b/cmd/calyptia/create_pipeline.go
@@ -18,7 +18,7 @@ import (
 )
 
 func newCmdCreatePipeline(config *config) *cobra.Command {
-	var aggregatorKey string
+	var coreInstanceKey string
 	var name string
 	var replicasCount uint
 	var configFile string
@@ -95,12 +95,12 @@ func newCmdCreatePipeline(config *config) *cobra.Command {
 				}
 			}
 
-			aggregatorID, err := config.loadAggregatorID(aggregatorKey, environmentID)
+			coreInstanceID, err := config.loadCoreInstanceID(coreInstanceKey, environmentID)
 			if err != nil {
 				return err
 			}
 
-			a, err := config.cloud.CreatePipeline(config.ctx, aggregatorID, cloud.CreatePipeline{
+			a, err := config.cloud.CreatePipeline(config.ctx, coreInstanceID, cloud.CreatePipeline{
 				Name:                      name,
 				ReplicasCount:             replicasCount,
 				RawConfig:                 string(rawConfig),
@@ -141,7 +141,7 @@ func newCmdCreatePipeline(config *config) *cobra.Command {
 	}
 
 	fs := cmd.Flags()
-	fs.StringVar(&aggregatorKey, "aggregator", "", "Parent aggregator ID or name")
+	fs.StringVar(&coreInstanceKey, "core_instance", "", "Parent core_instance ID or name")
 	fs.StringVar(&name, "name", "", "Pipeline name; leave it empty to generate a random name")
 	fs.UintVar(&replicasCount, "replicas", 1, "Pipeline replica size")
 	fs.StringVar(&configFile, "config-file", "fluent-bit.conf", "Fluent Bit config file used by pipeline")
@@ -159,14 +159,14 @@ func newCmdCreatePipeline(config *config) *cobra.Command {
 	fs.StringVar(&goTemplate, "template", "", "Template string or path to use when -o=go-template, -o=go-template-file. The template format is golang templates\n[http://golang.org/pkg/text/template/#pkg-overview]")
 
 	_ = cmd.RegisterFlagCompletionFunc("environment", config.completeEnvironments)
-	_ = cmd.RegisterFlagCompletionFunc("aggregator", config.completeAggregators)
+	_ = cmd.RegisterFlagCompletionFunc("core_instance", config.completeCoreInstances)
 	_ = cmd.RegisterFlagCompletionFunc("secrets-format", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return []string{"auto", "env", "json", "yaml"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	_ = cmd.RegisterFlagCompletionFunc("output-format", config.completeOutputFormat)
 	_ = cmd.RegisterFlagCompletionFunc("resource-profile", config.completeResourceProfiles)
 
-	_ = cmd.MarkFlagRequired("aggregator") // TODO: use default aggregator key from config cmd.
+	_ = cmd.MarkFlagRequired("core_instance") // TODO: use default core_instance key from config cmd.
 
 	return cmd
 }

--- a/cmd/calyptia/create_pipeline_test.go
+++ b/cmd/calyptia/create_pipeline_test.go
@@ -23,7 +23,7 @@ func Test_newCmdCreatePipeline(t *testing.T) {
 		AggregatorsFunc: func(ctx context.Context, projectID string, params types.AggregatorsParams) (types.Aggregators, error) {
 			return types.Aggregators{
 				Items: []types.Aggregator{{
-					ID: "want_aggregator",
+					ID: "want_core_instance",
 				}},
 			}, nil
 		},
@@ -40,7 +40,7 @@ func Test_newCmdCreatePipeline(t *testing.T) {
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 	cmd.SetArgs([]string{
-		"--aggregator", "want_aggregator",
+		"--core_instance", "want_core_instance",
 		"--name", "want_name",
 		"--replicas", "33",
 		"--config-file", configFile.Name(),
@@ -58,7 +58,7 @@ func Test_newCmdCreatePipeline(t *testing.T) {
 	wantEq(t, 1, len(calls))
 
 	call := calls[0]
-	wantEq(t, "want_aggregator", call.AggregatorID)
+	wantEq(t, "want_core_instance", call.AggregatorID)
 	wantEq(t, "want_name", call.Payload.Name)
 	wantEq(t, uint(33), call.Payload.ReplicasCount)
 	wantEq(t, 1, len(call.Payload.Files))
@@ -68,5 +68,5 @@ func Test_newCmdCreatePipeline(t *testing.T) {
 	wantEq(t, 1, len(call.Payload.Secrets))
 	wantEq(t, "FOO", call.Payload.Secrets[0].Key)
 	wantEq(t, []byte("BAR"), call.Payload.Secrets[0].Value)
-	wantEq(t, json.RawMessage([]byte(`{"foo":"bar"}`)), *call.Payload.Metadata)
+	wantEq(t, json.RawMessage(`{"foo":"bar"}`), *call.Payload.Metadata)
 }

--- a/cmd/calyptia/create_resource_profile.go
+++ b/cmd/calyptia/create_resource_profile.go
@@ -43,7 +43,7 @@ var resourceProfileSpecExample = func() string {
 }()
 
 func newCmdCreateResourceProfile(config *config) *cobra.Command {
-	var aggregatorKey string
+	var coreInstanceKey string
 	var name string
 	var specFile string
 	var outputFormat, goTemplate string
@@ -51,7 +51,7 @@ func newCmdCreateResourceProfile(config *config) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "resource_profile",
-		Short: "Create a new resource profile attached to an aggregator",
+		Short: "Create a new resource profile attached to a core_instance",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rawSpec, err := readFile(specFile)
 			if err != nil {
@@ -73,7 +73,7 @@ func newCmdCreateResourceProfile(config *config) *cobra.Command {
 				}
 			}
 
-			aggregatorID, err := config.loadAggregatorID(aggregatorKey, environmentID)
+			aggregatorID, err := config.loadCoreInstanceID(coreInstanceKey, environmentID)
 			if err != nil {
 				return err
 			}
@@ -117,7 +117,7 @@ func newCmdCreateResourceProfile(config *config) *cobra.Command {
 	}
 
 	fs := cmd.Flags()
-	fs.StringVar(&aggregatorKey, "aggregator", "", "Parent aggregator ID or name")
+	fs.StringVar(&coreInstanceKey, "core_instance", "", "Parent core_instance ID or name")
 	fs.StringVar(&name, "name", "", "Resource profile name")
 	fs.StringVar(&specFile, "spec", "", "Take spec from JSON file. Example:\n"+resourceProfileSpecExample)
 	fs.StringVar(&environment, "environment", "", "Calyptia environment name")
@@ -125,13 +125,13 @@ func newCmdCreateResourceProfile(config *config) *cobra.Command {
 	fs.StringVar(&goTemplate, "template", "", "Template string or path to use when -o=go-template, -o=go-template-file. The template format is golang templates\n[http://golang.org/pkg/text/template/#pkg-overview]")
 
 	_ = cmd.RegisterFlagCompletionFunc("environment", config.completeEnvironments)
-	_ = cmd.RegisterFlagCompletionFunc("aggregator", config.completeAggregators)
+	_ = cmd.RegisterFlagCompletionFunc("core_instance", config.completeCoreInstances)
 	_ = cmd.RegisterFlagCompletionFunc("output-format", config.completeOutputFormat)
 	_ = cmd.RegisterFlagCompletionFunc("name", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	})
 
-	_ = cmd.MarkFlagRequired("aggregator") // TODO: use default aggregator key from config cmd.
+	_ = cmd.MarkFlagRequired("core_instance") // TODO: use default core_instance key from config cmd.
 	_ = cmd.MarkFlagRequired("name")
 	_ = cmd.MarkFlagRequired("spec")
 

--- a/cmd/calyptia/create_resource_profile_test.go
+++ b/cmd/calyptia/create_resource_profile_test.go
@@ -18,8 +18,8 @@ func Test_newCmdCreateResourceProfile(t *testing.T) {
 		AggregatorsFunc: func(ctx context.Context, projectID string, params types.AggregatorsParams) (types.Aggregators, error) {
 			return types.Aggregators{
 				Items: []types.Aggregator{{
-					ID:   "want_aggregator",
-					Name: "want_aggregator",
+					ID:   "want_core_instance",
+					Name: "want_core_instance",
 				}},
 			}, nil
 		},
@@ -35,7 +35,7 @@ func Test_newCmdCreateResourceProfile(t *testing.T) {
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 	cmd.SetArgs([]string{
-		"--aggregator", "want_aggregator",
+		"--core_instance", "want_core_instance",
 		"--name", "want_name",
 		"--spec", spec.Name(),
 	})
@@ -49,6 +49,6 @@ func Test_newCmdCreateResourceProfile(t *testing.T) {
 	wantEq(t, 1, len(calls))
 
 	call := calls[0]
-	wantEq(t, "want_aggregator", call.AggregatorID)
+	wantEq(t, "want_core_instance", call.AggregatorID)
 	wantEq(t, "want_name", call.Payload.Name)
 }

--- a/cmd/calyptia/delete_core_instance.go
+++ b/cmd/calyptia/delete_core_instance.go
@@ -15,7 +15,7 @@ import (
 func newCmdDeleteCoreInstance(config *config, testClientSet kubernetes.Interface) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "core_instance",
-		Aliases: []string{"instance", "aggregator"},
+		Aliases: []string{"instance", "core_instance"},
 		Short:   "Delete a core instance from either Kubernetes, Amazon EC2, or Google Compute Engine",
 	}
 	cmd.AddCommand(
@@ -47,7 +47,7 @@ func newCmdDeleteCoreInstances(config *config) *cobra.Command {
 			}
 
 			if !confirmed {
-				cmd.Printf("You are about to delete:\n\n%s\n\nAre you sure you want to delete all of them? (y/N) ", strings.Join(aggregatorsKeys(aa.Items), "\n"))
+				cmd.Printf("You are about to delete:\n\n%s\n\nAre you sure you want to delete all of them? (y/N) ", strings.Join(coreInstanceKeys(aa.Items), "\n"))
 				confirmed, err := readConfirm(cmd.InOrStdin())
 				if err != nil {
 					return err

--- a/cmd/calyptia/delete_core_instance_aws.go
+++ b/cmd/calyptia/delete_core_instance_aws.go
@@ -29,7 +29,7 @@ func newCmdDeleteCoreInstanceOnAWS(config *config, client awsclient.Client) *cob
 		Aliases:           []string{"ec2", "amazon"},
 		Short:             "Delete a core instance from Amazon EC2",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: config.completeAggregators,
+		ValidArgsFunction: config.completeCoreInstances,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
@@ -44,7 +44,7 @@ func newCmdDeleteCoreInstanceOnAWS(config *config, client awsclient.Client) *cob
 				}
 			}
 
-			coreInstanceID, err := config.loadAggregatorID(coreInstanceName, environmentID)
+			coreInstanceID, err := config.loadCoreInstanceID(coreInstanceName, environmentID)
 			if !skipError && err != nil {
 				return fmt.Errorf("could not load core instance ID: %w", err)
 			}

--- a/cmd/calyptia/delete_core_instance_aws_test.go
+++ b/cmd/calyptia/delete_core_instance_aws_test.go
@@ -112,7 +112,7 @@ func Test_newCmdDeleteCoreInstanceOnAWS(t *testing.T) {
 		)
 
 		cmd.SetOut(&got)
-		cmd.SetArgs([]string{"core-instance", "--environment", "default"})
+		cmd.SetArgs([]string{"core_instance", "--environment", "default"})
 
 		err := cmd.Execute()
 		wantNoEq(t, nil, err)
@@ -138,7 +138,7 @@ func Test_newCmdDeleteCoreInstanceOnAWS(t *testing.T) {
 						return types.Environments{Items: []types.Environment{{Name: "default"}}}, nil
 					},
 					AggregatorsFunc: func(ctx context.Context, projectID string, params types.AggregatorsParams) (types.Aggregators, error) {
-						return types.Aggregators{}, fmt.Errorf("could not get aggregator")
+						return types.Aggregators{}, fmt.Errorf("could not get core_instance")
 					},
 				}),
 			&aws.ClientMock{
@@ -159,7 +159,7 @@ func Test_newCmdDeleteCoreInstanceOnAWS(t *testing.T) {
 
 		err := cmd.Execute()
 		wantNoEq(t, nil, err)
-		wantErrMsg(t, `could not load core instance ID: could not get aggregator`, err)
+		wantErrMsg(t, `could not load core instance ID: could not get core_instance`, err)
 
 	})
 

--- a/cmd/calyptia/delete_core_instance_gcp.go
+++ b/cmd/calyptia/delete_core_instance_gcp.go
@@ -26,7 +26,7 @@ func newCmdDeleteCoreInstanceOnGCP(config *config, client gcp.Client) *cobra.Com
 		Aliases:           []string{"google", "gce"},
 		Short:             "Delete a core instance from Google Compute Engine",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: config.completeAggregators,
+		ValidArgsFunction: config.completeCoreInstances,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			coreInstanceName := args[0]
 			ctx := cmd.Context()

--- a/cmd/calyptia/delete_core_instance_k8s.go
+++ b/cmd/calyptia/delete_core_instance_k8s.go
@@ -31,7 +31,7 @@ func newCmdDeleteCoreInstanceK8s(config *config, testClientSet kubernetes.Interf
 		Aliases:           []string{"kube", "k8s"},
 		Short:             "Delete a core instance and all of its kubernetes resources",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: config.completeAggregators,
+		ValidArgsFunction: config.completeCoreInstances,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			var environmentID string
@@ -43,15 +43,14 @@ func newCmdDeleteCoreInstanceK8s(config *config, testClientSet kubernetes.Interf
 				}
 			}
 
-			aggregatorKey := args[0]
-
-			aggregatorID, err := config.loadAggregatorID(aggregatorKey, environmentID)
+			coreInstanceKey := args[0]
+			coreInstanceID, err := config.loadCoreInstanceID(coreInstanceKey, environmentID)
 			if err != nil {
 				return err
 			}
 
 			if !confirmed {
-				cmd.Printf("Are you sure you want to delete core instance with id %q and all of its associated kubernetes resources? (y/N) ", aggregatorID)
+				cmd.Printf("Are you sure you want to delete core instance with id %q and all of its associated kubernetes resources? (y/N) ", coreInstanceID)
 				confirmed, err := readConfirm(cmd.InOrStdin())
 				if err != nil {
 					return err
@@ -63,7 +62,7 @@ func newCmdDeleteCoreInstanceK8s(config *config, testClientSet kubernetes.Interf
 				}
 			}
 
-			agg, err := config.cloud.Aggregator(ctx, aggregatorID)
+			agg, err := config.cloud.Aggregator(ctx, coreInstanceID)
 			if err != nil {
 				return err
 			}

--- a/cmd/calyptia/delete_environment.go
+++ b/cmd/calyptia/delete_environment.go
@@ -29,7 +29,7 @@ func newCmdDeleteEnvironment(c *config) *cobra.Command {
 			}
 			environment := environments.Items[0]
 			if !confirmDelete {
-				cmd.Print("This will remove ALL your agents, aggregators. Do you confirm? [y/N] ")
+				cmd.Print("This will remove ALL your agents, core_instances. Do you confirm? [y/N] ")
 				confirmDelete, err = readConfirm(cmd.InOrStdin())
 				if err != nil {
 					return err

--- a/cmd/calyptia/delete_pipeline.go
+++ b/cmd/calyptia/delete_pipeline.go
@@ -60,7 +60,7 @@ func newCmdDeletePipeline(config *config) *cobra.Command {
 
 func newCmdDeletePipelines(config *config) *cobra.Command {
 	var confirmed bool
-	var aggregatorKey string
+	var coreInstanceKey string
 	var environmentKey string
 
 	cmd := &cobra.Command{
@@ -77,12 +77,12 @@ func newCmdDeletePipelines(config *config) *cobra.Command {
 				}
 			}
 
-			aggregatorID, err := config.loadAggregatorID(aggregatorKey, environmentID)
+			coreInstanceID, err := config.loadCoreInstanceID(coreInstanceKey, environmentID)
 			if err != nil {
 				return err
 			}
 
-			pp, err := config.cloud.Pipelines(ctx, aggregatorID, types.PipelinesParams{
+			pp, err := config.cloud.Pipelines(ctx, coreInstanceID, types.PipelinesParams{
 				Last: ptr(uint(0)),
 			})
 			if err != nil {
@@ -112,7 +112,7 @@ func newCmdDeletePipelines(config *config) *cobra.Command {
 				pipelineIDs[i] = p.ID
 			}
 
-			err = config.cloud.DeletePipelines(ctx, aggregatorID, pipelineIDs...)
+			err = config.cloud.DeletePipelines(ctx, coreInstanceID, pipelineIDs...)
 			if err != nil {
 				return fmt.Errorf("delete pipelines: %w", err)
 			}
@@ -127,13 +127,13 @@ func newCmdDeletePipelines(config *config) *cobra.Command {
 
 	fs := cmd.Flags()
 	fs.BoolVarP(&confirmed, "yes", "y", isNonInteractive, "Confirm deletion")
-	fs.StringVar(&aggregatorKey, "aggregator", "", "Parent aggregator ID or name")
+	fs.StringVar(&coreInstanceKey, "core_instance", "", "Parent core_instance ID or name")
 	fs.StringVar(&environmentKey, "environment", "", "Calyptia environment ID or name")
 
-	_ = cmd.RegisterFlagCompletionFunc("aggregator", config.completeAggregators)
+	_ = cmd.RegisterFlagCompletionFunc("core_instance", config.completeCoreInstances)
 	_ = cmd.RegisterFlagCompletionFunc("environment", config.completeEnvironments)
 
-	_ = cmd.MarkFlagRequired("aggregator")
+	_ = cmd.MarkFlagRequired("core_instance")
 
 	return cmd
 }

--- a/cmd/calyptia/get.go
+++ b/cmd/calyptia/get.go
@@ -12,7 +12,7 @@ func newCmdGet(config *config) *cobra.Command {
 		newCmdGetMembers(config),
 		newCmdGetAgents(config),
 		newCmdGetAgent(config),
-		newCmdGetAggregators(config),
+		newCmdGetCoreInstances(config),
 		newCmdGetPipelines(config),
 		newCmdGetPipeline(config),
 		newCmdGetEndpoints(config),

--- a/cmd/calyptia/get_core_instance.go
+++ b/cmd/calyptia/get_core_instance.go
@@ -12,7 +12,7 @@ import (
 	cloud "github.com/calyptia/api/types"
 )
 
-func newCmdGetAggregators(config *config) *cobra.Command {
+func newCmdGetCoreInstances(config *config) *cobra.Command {
 	var last uint
 	var showIDs bool
 	var showMetadata bool
@@ -21,7 +21,7 @@ func newCmdGetAggregators(config *config) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "core_instances",
-		Aliases: []string{"instances", "aggregators"},
+		Aliases: []string{"instances", "core_instances"},
 		Short:   "Display latest core instances from a project",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var environmentID string
@@ -101,7 +101,7 @@ func newCmdGetAggregators(config *config) *cobra.Command {
 	return cmd
 }
 
-func (config *config) completeAggregators(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func (config *config) completeCoreInstances(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	aa, err := config.cloud.Aggregators(config.ctx, config.projectID, cloud.AggregatorsParams{})
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
@@ -111,11 +111,11 @@ func (config *config) completeAggregators(cmd *cobra.Command, args []string, toC
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	return aggregatorsKeys(aa.Items), cobra.ShellCompDirectiveNoFileComp
+	return coreInstanceKeys(aa.Items), cobra.ShellCompDirectiveNoFileComp
 }
 
-// aggregatorsKeys returns unique aggregator names first and then IDs.
-func aggregatorsKeys(aa []cloud.Aggregator) []string {
+// coreInstanceKeys returns unique aggregator names first and then IDs.
+func coreInstanceKeys(aa []cloud.Aggregator) []string {
 	namesCount := map[string]int{}
 	for _, a := range aa {
 		if _, ok := namesCount[a.Name]; ok {
@@ -147,9 +147,9 @@ func aggregatorsKeys(aa []cloud.Aggregator) []string {
 	return out
 }
 
-func (config *config) loadAggregatorID(aggregatorKey string, environmentID string) (string, error) {
+func (config *config) loadCoreInstanceID(key string, environmentID string) (string, error) {
 	params := cloud.AggregatorsParams{
-		Name: &aggregatorKey,
+		Name: &key,
 		Last: ptr(uint(2)),
 	}
 
@@ -162,17 +162,17 @@ func (config *config) loadAggregatorID(aggregatorKey string, environmentID strin
 		return "", err
 	}
 
-	if len(aa.Items) != 1 && !validUUID(aggregatorKey) {
+	if len(aa.Items) != 1 && !validUUID(key) {
 		if len(aa.Items) != 0 {
-			return "", fmt.Errorf("ambiguous core instance name %q, use ID instead", aggregatorKey)
+			return "", fmt.Errorf("ambiguous core instance name %q, use ID instead", key)
 		}
 
-		return "", fmt.Errorf("could not find core instance %q", aggregatorKey)
+		return "", fmt.Errorf("could not find core instance %q", key)
 	}
 
 	if len(aa.Items) == 1 {
 		return aa.Items[0].ID, nil
 	}
 
-	return aggregatorKey, nil
+	return key, nil
 }

--- a/cmd/calyptia/get_core_instance_test.go
+++ b/cmd/calyptia/get_core_instance_test.go
@@ -22,7 +22,7 @@ func Test_newCmdGetAggregators(t *testing.T) {
 
 	t.Run("empty", func(t *testing.T) {
 		got := &bytes.Buffer{}
-		cmd := newCmdGetAggregators(configWithMock(nil))
+		cmd := newCmdGetCoreInstances(configWithMock(nil))
 		cmd.SetOutput(got)
 
 		err := cmd.Execute()
@@ -41,7 +41,7 @@ func Test_newCmdGetAggregators(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		want := errors.New("internal error")
-		cmd := newCmdGetAggregators(configWithMock(&ClientMock{
+		cmd := newCmdGetCoreInstances(configWithMock(&ClientMock{
 			AggregatorsFunc: func(ctx context.Context, projectID string, params cloud.AggregatorsParams) (cloud.Aggregators, error) {
 				return cloud.Aggregators{}, want
 			},
@@ -79,7 +79,7 @@ func Test_newCmdGetAggregators(t *testing.T) {
 			}},
 		}
 		got := &bytes.Buffer{}
-		cmd := newCmdGetAggregators(configWithMock(&ClientMock{
+		cmd := newCmdGetCoreInstances(configWithMock(&ClientMock{
 			AggregatorsFunc: func(ctx context.Context, projectID string, params cloud.AggregatorsParams) (cloud.Aggregators, error) {
 				wantNoEq(t, nil, params.Last)
 				wantEq(t, uint(2), *params.Last)
@@ -155,7 +155,7 @@ func Test_aggregatorsKeys(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := aggregatorsKeys(tc.given); !reflect.DeepEqual(got, tc.want) {
+			if got := coreInstanceKeys(tc.given); !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("Aggregators.Keys(%+v) = %v, want %v", tc.given, got, tc.want)
 			}
 		})

--- a/cmd/calyptia/get_ingest_check.go
+++ b/cmd/calyptia/get_ingest_check.go
@@ -94,7 +94,7 @@ func newCmdGetIngestChecks(c *config) *cobra.Command {
 					return err
 				}
 			}
-			aggregatorID, err := c.loadAggregatorID(id, environmentID)
+			aggregatorID, err := c.loadCoreInstanceID(id, environmentID)
 			if err != nil {
 				return err
 			}

--- a/cmd/calyptia/get_pipeline.go
+++ b/cmd/calyptia/get_pipeline.go
@@ -15,7 +15,7 @@ import (
 )
 
 func newCmdGetPipelines(config *config) *cobra.Command {
-	var aggregatorKey string
+	var coreInstanceKey string
 	var last uint
 	var outputFormat, goTemplate string
 	var showIDs bool
@@ -24,7 +24,7 @@ func newCmdGetPipelines(config *config) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "pipelines",
-		Short: "Display latest pipelines from an aggregator",
+		Short: "Display latest pipelines from an core_instance",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var environmentID string
 			if environment != "" {
@@ -34,12 +34,12 @@ func newCmdGetPipelines(config *config) *cobra.Command {
 					return err
 				}
 			}
-			aggregatorID, err := config.loadAggregatorID(aggregatorKey, environmentID)
+			coreInstanceID, err := config.loadCoreInstanceID(coreInstanceKey, environmentID)
 			if err != nil {
 				return err
 			}
 
-			pp, err := config.cloud.Pipelines(config.ctx, aggregatorID, cloud.PipelinesParams{
+			pp, err := config.cloud.Pipelines(config.ctx, coreInstanceID, cloud.PipelinesParams{
 				Last:                     &last,
 				RenderWithConfigSections: renderWithConfigSections,
 			})
@@ -77,7 +77,7 @@ func newCmdGetPipelines(config *config) *cobra.Command {
 	}
 
 	fs := cmd.Flags()
-	fs.StringVar(&aggregatorKey, "aggregator", "", "Parent aggregator ID or name")
+	fs.StringVar(&coreInstanceKey, "core_instance", "", "Parent core_instance ID or name")
 	fs.UintVarP(&last, "last", "l", 0, "Last `N` pipelines. 0 means no limit")
 	fs.BoolVar(&showIDs, "show-ids", false, "Include pipeline IDs in table output")
 	fs.StringVar(&environment, "environment", "", "Calyptia environment name")
@@ -87,9 +87,9 @@ func newCmdGetPipelines(config *config) *cobra.Command {
 
 	_ = cmd.RegisterFlagCompletionFunc("environment", config.completeEnvironments)
 	_ = cmd.RegisterFlagCompletionFunc("output-format", config.completeOutputFormat)
-	_ = cmd.RegisterFlagCompletionFunc("aggregator", config.completeAggregators)
+	_ = cmd.RegisterFlagCompletionFunc("core_instance", config.completeCoreInstances)
 
-	_ = cmd.MarkFlagRequired("aggregator") // TODO: use default aggregator ID from config cmd.
+	_ = cmd.MarkFlagRequired("core_instance") // TODO: use default core instance ID from config cmd.
 
 	return cmd
 }
@@ -250,7 +250,7 @@ func newCmdGetPipeline(config *config) *cobra.Command {
 func (config *config) fetchAllPipelines() ([]cloud.Pipeline, error) {
 	aa, err := config.cloud.Aggregators(config.ctx, config.projectID, cloud.AggregatorsParams{})
 	if err != nil {
-		return nil, fmt.Errorf("could not prefetch aggregators: %w", err)
+		return nil, fmt.Errorf("could not prefetch core_instances: %w", err)
 	}
 
 	if len(aa.Items) == 0 {

--- a/cmd/calyptia/get_pipeline.go
+++ b/cmd/calyptia/get_pipeline.go
@@ -24,7 +24,7 @@ func newCmdGetPipelines(config *config) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "pipelines",
-		Short: "Display latest pipelines from an core_instance",
+		Short: "Display latest pipelines from a core_instance",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var environmentID string
 			if environment != "" {

--- a/cmd/calyptia/get_pipeline_test.go
+++ b/cmd/calyptia/get_pipeline_test.go
@@ -17,19 +17,19 @@ func Test_newCmdGetPipelines(t *testing.T) {
 		cmd.SilenceErrors = true
 		cmd.SilenceUsage = true
 		got := cmd.Execute()
-		wantErrMsg(t, `required flag(s) "aggregator" not set`, got)
+		wantErrMsg(t, `required flag(s) "core_instance" not set`, got)
 	})
 
 	t.Run("error", func(t *testing.T) {
 		want := errors.New("internal error")
 		cmd := newCmdGetPipelines(configWithMock(&ClientMock{
-			PipelinesFunc: func(ctx context.Context, aggregatorID string, params types.PipelinesParams) (types.Pipelines, error) {
+			PipelinesFunc: func(ctx context.Context, coreInstanceID string, params types.PipelinesParams) (types.Pipelines, error) {
 				return types.Pipelines{}, want
 			},
 		}))
 		cmd.SilenceErrors = true
 		cmd.SilenceUsage = true
-		cmd.SetArgs([]string{"--aggregator=" + zeroUUID4})
+		cmd.SetArgs([]string{"--core_instance=" + zeroUUID4})
 		got := cmd.Execute()
 		wantEq(t, want, got)
 	})
@@ -57,14 +57,14 @@ func Test_newCmdGetPipelines(t *testing.T) {
 		}
 		got := &bytes.Buffer{}
 		cmd := newCmdGetPipelines(configWithMock(&ClientMock{
-			PipelinesFunc: func(ctx context.Context, aggregatorID string, params types.PipelinesParams) (types.Pipelines, error) {
+			PipelinesFunc: func(ctx context.Context, coreInstanceID string, params types.PipelinesParams) (types.Pipelines, error) {
 				wantNoEq(t, nil, params.Last)
 				wantEq(t, uint(2), *params.Last)
 				return want, nil
 			},
 		}))
 		cmd.SetOutput(got)
-		cmd.SetArgs([]string{"--aggregator=" + zeroUUID4, "--last=2"})
+		cmd.SetArgs([]string{"--core_instance=" + zeroUUID4, "--last=2"})
 
 		err := cmd.Execute()
 		wantEq(t, nil, err)
@@ -75,7 +75,7 @@ func Test_newCmdGetPipelines(t *testing.T) {
 
 		t.Run("show_ids", func(t *testing.T) {
 			got.Reset()
-			cmd.SetArgs([]string{"--aggregator=" + zeroUUID4, "--show-ids"})
+			cmd.SetArgs([]string{"--core_instance=" + zeroUUID4, "--show-ids"})
 
 			err := cmd.Execute()
 			wantEq(t, nil, err)
@@ -91,7 +91,7 @@ func Test_newCmdGetPipelines(t *testing.T) {
 			want, err := json.Marshal(want.Items)
 			wantEq(t, nil, err)
 
-			cmd.SetArgs([]string{"--aggregator=" + zeroUUID4, "--output-format=json"})
+			cmd.SetArgs([]string{"--core_instance=" + zeroUUID4, "--output-format=json"})
 
 			err = cmd.Execute()
 			wantEq(t, nil, err)

--- a/cmd/calyptia/get_resource_profile.go
+++ b/cmd/calyptia/get_resource_profile.go
@@ -13,7 +13,7 @@ import (
 )
 
 func newCmdGetResourceProfiles(config *config) *cobra.Command {
-	var aggregatorKey string
+	var coreInstanceKey string
 	var last uint
 	var outputFormat, goTemplate string
 	var showIDs bool
@@ -32,12 +32,12 @@ func newCmdGetResourceProfiles(config *config) *cobra.Command {
 				}
 			}
 
-			aggregatorID, err := config.loadAggregatorID(aggregatorKey, environmentID)
+			coreInstanceID, err := config.loadCoreInstanceID(coreInstanceKey, environmentID)
 			if err != nil {
 				return err
 			}
 
-			pp, err := config.cloud.ResourceProfiles(config.ctx, aggregatorID, cloud.ResourceProfilesParams{
+			pp, err := config.cloud.ResourceProfiles(config.ctx, coreInstanceID, cloud.ResourceProfilesParams{
 				Last: &last,
 			})
 			if err != nil {
@@ -74,7 +74,7 @@ func newCmdGetResourceProfiles(config *config) *cobra.Command {
 	}
 
 	fs := cmd.Flags()
-	fs.StringVar(&aggregatorKey, "aggregator", "", "Parent aggregator ID or name")
+	fs.StringVar(&coreInstanceKey, "core_instance", "", "Parent core_instance ID or name")
 	fs.UintVarP(&last, "last", "l", 0, "Last `N` pipelines. 0 means no limit")
 	fs.BoolVar(&showIDs, "show-ids", false, "Include resource profile IDs in table output")
 	fs.StringVar(&environment, "environment", "", "Calyptia environment name")
@@ -83,9 +83,9 @@ func newCmdGetResourceProfiles(config *config) *cobra.Command {
 
 	_ = cmd.RegisterFlagCompletionFunc("environment", config.completeEnvironments)
 	_ = cmd.RegisterFlagCompletionFunc("output-format", config.completeOutputFormat)
-	_ = cmd.RegisterFlagCompletionFunc("aggregator", config.completeAggregators)
+	_ = cmd.RegisterFlagCompletionFunc("core_instance", config.completeCoreInstances)
 
-	_ = cmd.MarkFlagRequired("aggregator") // TODO: use default aggregator ID from config cmd.
+	_ = cmd.MarkFlagRequired("core_instance") // TODO: use default aggregator ID from config cmd.
 
 	return cmd
 }

--- a/cmd/calyptia/get_resource_profile_test.go
+++ b/cmd/calyptia/get_resource_profile_test.go
@@ -18,14 +18,14 @@ func Test_newCmdGetResourceProfiles(t *testing.T) {
 		cmd.SetOutput(got)
 
 		err := cmd.Execute()
-		wantErrMsg(t, `required flag(s) "aggregator" not set`, err)
+		wantErrMsg(t, `required flag(s) "core_instance" not set`, err)
 	})
 
 	t.Run("empty", func(t *testing.T) {
 		got := &bytes.Buffer{}
 		cmd := newCmdGetResourceProfiles(configWithMock(nil))
 		cmd.SetOutput(got)
-		cmd.SetArgs([]string{"--aggregator=" + zeroUUID4})
+		cmd.SetArgs([]string{"--core_instance=" + zeroUUID4})
 
 		err := cmd.Execute()
 		wantEq(t, nil, err)
@@ -33,7 +33,7 @@ func Test_newCmdGetResourceProfiles(t *testing.T) {
 
 		t.Run("with_ids", func(t *testing.T) {
 			got.Reset()
-			cmd.SetArgs([]string{"--aggregator=" + zeroUUID4, "--show-ids"})
+			cmd.SetArgs([]string{"--core_instance=" + zeroUUID4, "--show-ids"})
 
 			err := cmd.Execute()
 			wantEq(t, nil, err)
@@ -44,11 +44,11 @@ func Test_newCmdGetResourceProfiles(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		want := errors.New("internal error")
 		cmd := newCmdGetResourceProfiles(configWithMock(&ClientMock{
-			ResourceProfilesFunc: func(ctx context.Context, aggregatorID string, params cloud.ResourceProfilesParams) (cloud.ResourceProfiles, error) {
+			ResourceProfilesFunc: func(ctx context.Context, coreInstanceID string, params cloud.ResourceProfilesParams) (cloud.ResourceProfiles, error) {
 				return cloud.ResourceProfiles{}, want
 			},
 		}))
-		cmd.SetArgs([]string{"--aggregator=" + zeroUUID4})
+		cmd.SetArgs([]string{"--core_instance=" + zeroUUID4})
 		cmd.SilenceErrors = true
 		cmd.SilenceUsage = true
 
@@ -91,13 +91,13 @@ func Test_newCmdGetResourceProfiles(t *testing.T) {
 		}
 		got := &bytes.Buffer{}
 		cmd := newCmdGetResourceProfiles(configWithMock(&ClientMock{
-			ResourceProfilesFunc: func(ctx context.Context, aggregatorID string, params cloud.ResourceProfilesParams) (cloud.ResourceProfiles, error) {
+			ResourceProfilesFunc: func(ctx context.Context, coreInstanceID string, params cloud.ResourceProfilesParams) (cloud.ResourceProfiles, error) {
 				wantNoEq(t, nil, params.Last)
 				wantEq(t, uint(2), *params.Last)
 				return want, nil
 			},
 		}))
-		cmd.SetArgs([]string{"--aggregator=" + zeroUUID4, "--last=2"})
+		cmd.SetArgs([]string{"--core_instance=" + zeroUUID4, "--last=2"})
 		cmd.SetOutput(got)
 
 		err := cmd.Execute()
@@ -109,7 +109,7 @@ func Test_newCmdGetResourceProfiles(t *testing.T) {
 
 		t.Run("with_ids", func(t *testing.T) {
 			got.Reset()
-			cmd.SetArgs([]string{"--aggregator=" + zeroUUID4, "--show-ids"})
+			cmd.SetArgs([]string{"--core_instance=" + zeroUUID4, "--show-ids"})
 
 			err := cmd.Execute()
 			wantEq(t, nil, err)
@@ -124,7 +124,7 @@ func Test_newCmdGetResourceProfiles(t *testing.T) {
 			wantEq(t, nil, err)
 
 			got.Reset()
-			cmd.SetArgs([]string{"--aggregator=" + zeroUUID4, "--output-format=json"})
+			cmd.SetArgs([]string{"--core_instance=" + zeroUUID4, "--output-format=json"})
 
 			err = cmd.Execute()
 			wantEq(t, nil, err)

--- a/cmd/calyptia/update_core_instance_aws.go
+++ b/cmd/calyptia/update_core_instance_aws.go
@@ -12,7 +12,7 @@ func newCmdUpdateCoreInstanceOnAWS(config *config) *cobra.Command {
 		Aliases:           []string{"ec2", "amazon"},
 		Short:             "Update a core instance from Amazon EC2 (TODO)",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: config.completeAggregators,
+		ValidArgsFunction: config.completeCoreInstances,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not implemented")
 		},

--- a/cmd/calyptia/update_core_instance_gcp.go
+++ b/cmd/calyptia/update_core_instance_gcp.go
@@ -12,7 +12,7 @@ func newCmdUpdateCoreInstanceOnGCP(config *config) *cobra.Command {
 		Aliases:           []string{"google", "gce"},
 		Short:             "Update a core instance from Google Compute Engine (TODO)",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: config.completeAggregators,
+		ValidArgsFunction: config.completeCoreInstances,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not implemented")
 		},

--- a/cmd/calyptia/update_core_instance_k8s.go
+++ b/cmd/calyptia/update_core_instance_k8s.go
@@ -27,10 +27,10 @@ func newCmdUpdateCoreInstanceK8s(config *config, testClientSet kubernetes.Interf
 		Aliases:           []string{"kube", "k8s"},
 		Short:             "update a core instance from kubernetes",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: config.completeAggregators,
+		ValidArgsFunction: config.completeCoreInstances,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			aggregatorKey := args[0]
+			coreInstanceKey := args[0]
 
 			var environmentID string
 			if environment != "" {
@@ -40,12 +40,12 @@ func newCmdUpdateCoreInstanceK8s(config *config, testClientSet kubernetes.Interf
 					return err
 				}
 			}
-			aggregatorID, err := config.loadAggregatorID(aggregatorKey, environmentID)
+			coreInstanceID, err := config.loadCoreInstanceID(coreInstanceKey, environmentID)
 			if err != nil {
 				return err
 			}
 
-			if aggregatorKey == newName {
+			if coreInstanceKey == newName {
 				return fmt.Errorf("cannot update core instance with the same name")
 			}
 
@@ -66,12 +66,12 @@ func newCmdUpdateCoreInstanceK8s(config *config, testClientSet kubernetes.Interf
 				opts.ClusterLogging = &disableClusterLogging
 			}
 
-			err = config.cloud.UpdateAggregator(config.ctx, aggregatorID, opts)
+			err = config.cloud.UpdateAggregator(config.ctx, coreInstanceID, opts)
 			if err != nil {
 				return fmt.Errorf("could not update core instance at calyptia cloud: %w", err)
 			}
 
-			agg, err := config.cloud.Aggregator(ctx, aggregatorID)
+			agg, err := config.cloud.Aggregator(ctx, coreInstanceID)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
# Summary of this proposal

This is just a parameter rename, it doesn't takes cares of the client/API refactor to resort
everything to the core_instance nomenclature, that will come as part a renaming refactor previous
to release 1.0 on cloud.

For now, rename the parameters from --aggregator to --core_instance to make it consistent.

Fixes bug #252

Signed-off-by: Jorge Niedbalski <j@calyptia.com>