### PR TITLE
Set first level object names as underscore_name and parameters as hyphen separated.

### DIFF
--- a/cmd/calyptia/create_ingest_check.go
+++ b/cmd/calyptia/create_ingest_check.go
@@ -17,7 +17,7 @@ func newCmdCreateIngestCheck(config *config) *cobra.Command {
 		environment     string
 	)
 	cmd := &cobra.Command{
-		Use:   "ingest-check CORE_INSTANCE",
+		Use:   "ingest_check CORE_INSTANCE",
 		Short: "Create an ingest check",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/calyptia/create_pipeline.go
+++ b/cmd/calyptia/create_pipeline.go
@@ -141,7 +141,7 @@ func newCmdCreatePipeline(config *config) *cobra.Command {
 	}
 
 	fs := cmd.Flags()
-	fs.StringVar(&coreInstanceKey, "core_instance", "", "Parent core_instance ID or name")
+	fs.StringVar(&coreInstanceKey, "core-instance", "", "Parent core-instance ID or name")
 	fs.StringVar(&name, "name", "", "Pipeline name; leave it empty to generate a random name")
 	fs.UintVar(&replicasCount, "replicas", 1, "Pipeline replica size")
 	fs.StringVar(&configFile, "config-file", "fluent-bit.conf", "Fluent Bit config file used by pipeline")
@@ -159,14 +159,14 @@ func newCmdCreatePipeline(config *config) *cobra.Command {
 	fs.StringVar(&goTemplate, "template", "", "Template string or path to use when -o=go-template, -o=go-template-file. The template format is golang templates\n[http://golang.org/pkg/text/template/#pkg-overview]")
 
 	_ = cmd.RegisterFlagCompletionFunc("environment", config.completeEnvironments)
-	_ = cmd.RegisterFlagCompletionFunc("core_instance", config.completeCoreInstances)
+	_ = cmd.RegisterFlagCompletionFunc("core-instance", config.completeCoreInstances)
 	_ = cmd.RegisterFlagCompletionFunc("secrets-format", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return []string{"auto", "env", "json", "yaml"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	_ = cmd.RegisterFlagCompletionFunc("output-format", config.completeOutputFormat)
 	_ = cmd.RegisterFlagCompletionFunc("resource-profile", config.completeResourceProfiles)
 
-	_ = cmd.MarkFlagRequired("core_instance") // TODO: use default core_instance key from config cmd.
+	_ = cmd.MarkFlagRequired("core-instance") // TODO: use default core-instance key from config cmd.
 
 	return cmd
 }

--- a/cmd/calyptia/create_pipeline_test.go
+++ b/cmd/calyptia/create_pipeline_test.go
@@ -23,7 +23,7 @@ func Test_newCmdCreatePipeline(t *testing.T) {
 		AggregatorsFunc: func(ctx context.Context, projectID string, params types.AggregatorsParams) (types.Aggregators, error) {
 			return types.Aggregators{
 				Items: []types.Aggregator{{
-					ID: "want_core_instance",
+					ID: "want_core-instance",
 				}},
 			}, nil
 		},
@@ -40,7 +40,7 @@ func Test_newCmdCreatePipeline(t *testing.T) {
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 	cmd.SetArgs([]string{
-		"--core_instance", "want_core_instance",
+		"--core-instance", "want_core-instance",
 		"--name", "want_name",
 		"--replicas", "33",
 		"--config-file", configFile.Name(),
@@ -58,7 +58,7 @@ func Test_newCmdCreatePipeline(t *testing.T) {
 	wantEq(t, 1, len(calls))
 
 	call := calls[0]
-	wantEq(t, "want_core_instance", call.AggregatorID)
+	wantEq(t, "want_core-instance", call.AggregatorID)
 	wantEq(t, "want_name", call.Payload.Name)
 	wantEq(t, uint(33), call.Payload.ReplicasCount)
 	wantEq(t, 1, len(call.Payload.Files))

--- a/cmd/calyptia/create_pipeline_test.go
+++ b/cmd/calyptia/create_pipeline_test.go
@@ -23,7 +23,7 @@ func Test_newCmdCreatePipeline(t *testing.T) {
 		AggregatorsFunc: func(ctx context.Context, projectID string, params types.AggregatorsParams) (types.Aggregators, error) {
 			return types.Aggregators{
 				Items: []types.Aggregator{{
-					ID: "want_core-instance",
+					ID: "want_core_instance",
 				}},
 			}, nil
 		},
@@ -40,7 +40,7 @@ func Test_newCmdCreatePipeline(t *testing.T) {
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 	cmd.SetArgs([]string{
-		"--core-instance", "want_core-instance",
+		"--core-instance", "want_core_instance",
 		"--name", "want_name",
 		"--replicas", "33",
 		"--config-file", configFile.Name(),
@@ -58,7 +58,7 @@ func Test_newCmdCreatePipeline(t *testing.T) {
 	wantEq(t, 1, len(calls))
 
 	call := calls[0]
-	wantEq(t, "want_core-instance", call.AggregatorID)
+	wantEq(t, "want_core_instance", call.AggregatorID)
 	wantEq(t, "want_name", call.Payload.Name)
 	wantEq(t, uint(33), call.Payload.ReplicasCount)
 	wantEq(t, 1, len(call.Payload.Files))

--- a/cmd/calyptia/create_resource_profile.go
+++ b/cmd/calyptia/create_resource_profile.go
@@ -51,7 +51,7 @@ func newCmdCreateResourceProfile(config *config) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "resource_profile",
-		Short: "Create a new resource profile attached to a core_instance",
+		Short: "Create a new resource profile attached to a core-instance",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rawSpec, err := readFile(specFile)
 			if err != nil {
@@ -117,7 +117,7 @@ func newCmdCreateResourceProfile(config *config) *cobra.Command {
 	}
 
 	fs := cmd.Flags()
-	fs.StringVar(&coreInstanceKey, "core_instance", "", "Parent core_instance ID or name")
+	fs.StringVar(&coreInstanceKey, "core-instance", "", "Parent core-instance ID or name")
 	fs.StringVar(&name, "name", "", "Resource profile name")
 	fs.StringVar(&specFile, "spec", "", "Take spec from JSON file. Example:\n"+resourceProfileSpecExample)
 	fs.StringVar(&environment, "environment", "", "Calyptia environment name")
@@ -125,13 +125,13 @@ func newCmdCreateResourceProfile(config *config) *cobra.Command {
 	fs.StringVar(&goTemplate, "template", "", "Template string or path to use when -o=go-template, -o=go-template-file. The template format is golang templates\n[http://golang.org/pkg/text/template/#pkg-overview]")
 
 	_ = cmd.RegisterFlagCompletionFunc("environment", config.completeEnvironments)
-	_ = cmd.RegisterFlagCompletionFunc("core_instance", config.completeCoreInstances)
+	_ = cmd.RegisterFlagCompletionFunc("core-instance", config.completeCoreInstances)
 	_ = cmd.RegisterFlagCompletionFunc("output-format", config.completeOutputFormat)
 	_ = cmd.RegisterFlagCompletionFunc("name", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	})
 
-	_ = cmd.MarkFlagRequired("core_instance") // TODO: use default core_instance key from config cmd.
+	_ = cmd.MarkFlagRequired("core-instance") // TODO: use default core-instance key from config cmd.
 	_ = cmd.MarkFlagRequired("name")
 	_ = cmd.MarkFlagRequired("spec")
 

--- a/cmd/calyptia/create_resource_profile_test.go
+++ b/cmd/calyptia/create_resource_profile_test.go
@@ -18,8 +18,8 @@ func Test_newCmdCreateResourceProfile(t *testing.T) {
 		AggregatorsFunc: func(ctx context.Context, projectID string, params types.AggregatorsParams) (types.Aggregators, error) {
 			return types.Aggregators{
 				Items: []types.Aggregator{{
-					ID:   "want_core_instance",
-					Name: "want_core_instance",
+					ID:   "want_core-instance",
+					Name: "want_core-instance",
 				}},
 			}, nil
 		},
@@ -35,7 +35,7 @@ func Test_newCmdCreateResourceProfile(t *testing.T) {
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 	cmd.SetArgs([]string{
-		"--core_instance", "want_core_instance",
+		"--core-instance", "want_core-instance",
 		"--name", "want_name",
 		"--spec", spec.Name(),
 	})
@@ -49,6 +49,6 @@ func Test_newCmdCreateResourceProfile(t *testing.T) {
 	wantEq(t, 1, len(calls))
 
 	call := calls[0]
-	wantEq(t, "want_core_instance", call.AggregatorID)
+	wantEq(t, "want_core-instance", call.AggregatorID)
 	wantEq(t, "want_name", call.Payload.Name)
 }

--- a/cmd/calyptia/create_resource_profile_test.go
+++ b/cmd/calyptia/create_resource_profile_test.go
@@ -18,8 +18,8 @@ func Test_newCmdCreateResourceProfile(t *testing.T) {
 		AggregatorsFunc: func(ctx context.Context, projectID string, params types.AggregatorsParams) (types.Aggregators, error) {
 			return types.Aggregators{
 				Items: []types.Aggregator{{
-					ID:   "want_core-instance",
-					Name: "want_core-instance",
+					ID:   "want_core_instance",
+					Name: "want_core_instance",
 				}},
 			}, nil
 		},
@@ -35,7 +35,7 @@ func Test_newCmdCreateResourceProfile(t *testing.T) {
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 	cmd.SetArgs([]string{
-		"--core-instance", "want_core-instance",
+		"--core-instance", "want_core_instance",
 		"--name", "want_name",
 		"--spec", spec.Name(),
 	})
@@ -49,6 +49,6 @@ func Test_newCmdCreateResourceProfile(t *testing.T) {
 	wantEq(t, 1, len(calls))
 
 	call := calls[0]
-	wantEq(t, "want_core-instance", call.AggregatorID)
+	wantEq(t, "want_core_instance", call.AggregatorID)
 	wantEq(t, "want_name", call.Payload.Name)
 }

--- a/cmd/calyptia/delete_core_instance_aws_test.go
+++ b/cmd/calyptia/delete_core_instance_aws_test.go
@@ -112,7 +112,7 @@ func Test_newCmdDeleteCoreInstanceOnAWS(t *testing.T) {
 		)
 
 		cmd.SetOut(&got)
-		cmd.SetArgs([]string{"core_instance", "--environment", "default"})
+		cmd.SetArgs([]string{"core-instance", "--environment", "default"})
 
 		err := cmd.Execute()
 		wantNoEq(t, nil, err)
@@ -138,7 +138,7 @@ func Test_newCmdDeleteCoreInstanceOnAWS(t *testing.T) {
 						return types.Environments{Items: []types.Environment{{Name: "default"}}}, nil
 					},
 					AggregatorsFunc: func(ctx context.Context, projectID string, params types.AggregatorsParams) (types.Aggregators, error) {
-						return types.Aggregators{}, fmt.Errorf("could not get core_instance")
+						return types.Aggregators{}, fmt.Errorf("could not get core-instance")
 					},
 				}),
 			&aws.ClientMock{
@@ -159,7 +159,7 @@ func Test_newCmdDeleteCoreInstanceOnAWS(t *testing.T) {
 
 		err := cmd.Execute()
 		wantNoEq(t, nil, err)
-		wantErrMsg(t, `could not load core instance ID: could not get core_instance`, err)
+		wantErrMsg(t, `could not load core instance ID: could not get core-instance`, err)
 
 	})
 

--- a/cmd/calyptia/delete_ingest_check.go
+++ b/cmd/calyptia/delete_ingest_check.go
@@ -8,7 +8,7 @@ import (
 
 func newCmdDeleteIngestCheck(c *config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ingest-check INGEST_CHECK_ID",
+		Use:   "ingest_check INGEST_CHECK_ID",
 		Short: "Delete a specific ingest check",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/calyptia/delete_pipeline.go
+++ b/cmd/calyptia/delete_pipeline.go
@@ -127,13 +127,13 @@ func newCmdDeletePipelines(config *config) *cobra.Command {
 
 	fs := cmd.Flags()
 	fs.BoolVarP(&confirmed, "yes", "y", isNonInteractive, "Confirm deletion")
-	fs.StringVar(&coreInstanceKey, "core_instance", "", "Parent core_instance ID or name")
+	fs.StringVar(&coreInstanceKey, "core-instance", "", "Parent core-instance ID or name")
 	fs.StringVar(&environmentKey, "environment", "", "Calyptia environment ID or name")
 
-	_ = cmd.RegisterFlagCompletionFunc("core_instance", config.completeCoreInstances)
+	_ = cmd.RegisterFlagCompletionFunc("core-instance", config.completeCoreInstances)
 	_ = cmd.RegisterFlagCompletionFunc("environment", config.completeEnvironments)
 
-	_ = cmd.MarkFlagRequired("core_instance")
+	_ = cmd.MarkFlagRequired("core-instance")
 
 	return cmd
 }

--- a/cmd/calyptia/get_ingest_check.go
+++ b/cmd/calyptia/get_ingest_check.go
@@ -20,7 +20,7 @@ func newCmdGetIngestCheck(c *config) *cobra.Command {
 		goTemplate   string
 	)
 	cmd := &cobra.Command{
-		Use:   "ingest-check INGEST_CHECK_ID",
+		Use:   "ingest_check INGEST_CHECK_ID",
 		Short: "Get a specific ingest check",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -80,7 +80,7 @@ func newCmdGetIngestChecks(c *config) *cobra.Command {
 		environment  string
 	)
 	cmd := &cobra.Command{
-		Use:   "ingest-checks CORE_INSTANCE",
+		Use:   "ingest_checks CORE_INSTANCE",
 		Short: "Get a list of ingest checks",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/calyptia/get_pipeline.go
+++ b/cmd/calyptia/get_pipeline.go
@@ -24,7 +24,7 @@ func newCmdGetPipelines(config *config) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "pipelines",
-		Short: "Display latest pipelines from a core_instance",
+		Short: "Display latest pipelines from a core-instance",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var environmentID string
 			if environment != "" {
@@ -77,7 +77,7 @@ func newCmdGetPipelines(config *config) *cobra.Command {
 	}
 
 	fs := cmd.Flags()
-	fs.StringVar(&coreInstanceKey, "core_instance", "", "Parent core_instance ID or name")
+	fs.StringVar(&coreInstanceKey, "core-instance", "", "Parent core-instance ID or name")
 	fs.UintVarP(&last, "last", "l", 0, "Last `N` pipelines. 0 means no limit")
 	fs.BoolVar(&showIDs, "show-ids", false, "Include pipeline IDs in table output")
 	fs.StringVar(&environment, "environment", "", "Calyptia environment name")
@@ -87,9 +87,9 @@ func newCmdGetPipelines(config *config) *cobra.Command {
 
 	_ = cmd.RegisterFlagCompletionFunc("environment", config.completeEnvironments)
 	_ = cmd.RegisterFlagCompletionFunc("output-format", config.completeOutputFormat)
-	_ = cmd.RegisterFlagCompletionFunc("core_instance", config.completeCoreInstances)
+	_ = cmd.RegisterFlagCompletionFunc("core-instance", config.completeCoreInstances)
 
-	_ = cmd.MarkFlagRequired("core_instance") // TODO: use default core instance ID from config cmd.
+	_ = cmd.MarkFlagRequired("core-instance") // TODO: use default core instance ID from config cmd.
 
 	return cmd
 }
@@ -250,7 +250,7 @@ func newCmdGetPipeline(config *config) *cobra.Command {
 func (config *config) fetchAllPipelines() ([]cloud.Pipeline, error) {
 	aa, err := config.cloud.Aggregators(config.ctx, config.projectID, cloud.AggregatorsParams{})
 	if err != nil {
-		return nil, fmt.Errorf("could not prefetch core_instances: %w", err)
+		return nil, fmt.Errorf("could not prefetch core-instances: %w", err)
 	}
 
 	if len(aa.Items) == 0 {

--- a/cmd/calyptia/get_pipeline_test.go
+++ b/cmd/calyptia/get_pipeline_test.go
@@ -17,7 +17,7 @@ func Test_newCmdGetPipelines(t *testing.T) {
 		cmd.SilenceErrors = true
 		cmd.SilenceUsage = true
 		got := cmd.Execute()
-		wantErrMsg(t, `required flag(s) "core_instance" not set`, got)
+		wantErrMsg(t, `required flag(s) "core-instance" not set`, got)
 	})
 
 	t.Run("error", func(t *testing.T) {
@@ -29,7 +29,7 @@ func Test_newCmdGetPipelines(t *testing.T) {
 		}))
 		cmd.SilenceErrors = true
 		cmd.SilenceUsage = true
-		cmd.SetArgs([]string{"--core_instance=" + zeroUUID4})
+		cmd.SetArgs([]string{"--core-instance=" + zeroUUID4})
 		got := cmd.Execute()
 		wantEq(t, want, got)
 	})
@@ -64,7 +64,7 @@ func Test_newCmdGetPipelines(t *testing.T) {
 			},
 		}))
 		cmd.SetOutput(got)
-		cmd.SetArgs([]string{"--core_instance=" + zeroUUID4, "--last=2"})
+		cmd.SetArgs([]string{"--core-instance=" + zeroUUID4, "--last=2"})
 
 		err := cmd.Execute()
 		wantEq(t, nil, err)
@@ -75,7 +75,7 @@ func Test_newCmdGetPipelines(t *testing.T) {
 
 		t.Run("show_ids", func(t *testing.T) {
 			got.Reset()
-			cmd.SetArgs([]string{"--core_instance=" + zeroUUID4, "--show-ids"})
+			cmd.SetArgs([]string{"--core-instance=" + zeroUUID4, "--show-ids"})
 
 			err := cmd.Execute()
 			wantEq(t, nil, err)
@@ -91,7 +91,7 @@ func Test_newCmdGetPipelines(t *testing.T) {
 			want, err := json.Marshal(want.Items)
 			wantEq(t, nil, err)
 
-			cmd.SetArgs([]string{"--core_instance=" + zeroUUID4, "--output-format=json"})
+			cmd.SetArgs([]string{"--core-instance=" + zeroUUID4, "--output-format=json"})
 
 			err = cmd.Execute()
 			wantEq(t, nil, err)

--- a/cmd/calyptia/get_resource_profile.go
+++ b/cmd/calyptia/get_resource_profile.go
@@ -74,7 +74,7 @@ func newCmdGetResourceProfiles(config *config) *cobra.Command {
 	}
 
 	fs := cmd.Flags()
-	fs.StringVar(&coreInstanceKey, "core_instance", "", "Parent core_instance ID or name")
+	fs.StringVar(&coreInstanceKey, "core-instance", "", "Parent core-instance ID or name")
 	fs.UintVarP(&last, "last", "l", 0, "Last `N` pipelines. 0 means no limit")
 	fs.BoolVar(&showIDs, "show-ids", false, "Include resource profile IDs in table output")
 	fs.StringVar(&environment, "environment", "", "Calyptia environment name")
@@ -83,9 +83,9 @@ func newCmdGetResourceProfiles(config *config) *cobra.Command {
 
 	_ = cmd.RegisterFlagCompletionFunc("environment", config.completeEnvironments)
 	_ = cmd.RegisterFlagCompletionFunc("output-format", config.completeOutputFormat)
-	_ = cmd.RegisterFlagCompletionFunc("core_instance", config.completeCoreInstances)
+	_ = cmd.RegisterFlagCompletionFunc("core-instance", config.completeCoreInstances)
 
-	_ = cmd.MarkFlagRequired("core_instance") // TODO: use default aggregator ID from config cmd.
+	_ = cmd.MarkFlagRequired("core-instance") // TODO: use default aggregator ID from config cmd.
 
 	return cmd
 }

--- a/cmd/calyptia/get_resource_profile_test.go
+++ b/cmd/calyptia/get_resource_profile_test.go
@@ -18,14 +18,14 @@ func Test_newCmdGetResourceProfiles(t *testing.T) {
 		cmd.SetOutput(got)
 
 		err := cmd.Execute()
-		wantErrMsg(t, `required flag(s) "core_instance" not set`, err)
+		wantErrMsg(t, `required flag(s) "core-instance" not set`, err)
 	})
 
 	t.Run("empty", func(t *testing.T) {
 		got := &bytes.Buffer{}
 		cmd := newCmdGetResourceProfiles(configWithMock(nil))
 		cmd.SetOutput(got)
-		cmd.SetArgs([]string{"--core_instance=" + zeroUUID4})
+		cmd.SetArgs([]string{"--core-instance=" + zeroUUID4})
 
 		err := cmd.Execute()
 		wantEq(t, nil, err)
@@ -33,7 +33,7 @@ func Test_newCmdGetResourceProfiles(t *testing.T) {
 
 		t.Run("with_ids", func(t *testing.T) {
 			got.Reset()
-			cmd.SetArgs([]string{"--core_instance=" + zeroUUID4, "--show-ids"})
+			cmd.SetArgs([]string{"--core-instance=" + zeroUUID4, "--show-ids"})
 
 			err := cmd.Execute()
 			wantEq(t, nil, err)
@@ -48,7 +48,7 @@ func Test_newCmdGetResourceProfiles(t *testing.T) {
 				return cloud.ResourceProfiles{}, want
 			},
 		}))
-		cmd.SetArgs([]string{"--core_instance=" + zeroUUID4})
+		cmd.SetArgs([]string{"--core-instance=" + zeroUUID4})
 		cmd.SilenceErrors = true
 		cmd.SilenceUsage = true
 
@@ -97,7 +97,7 @@ func Test_newCmdGetResourceProfiles(t *testing.T) {
 				return want, nil
 			},
 		}))
-		cmd.SetArgs([]string{"--core_instance=" + zeroUUID4, "--last=2"})
+		cmd.SetArgs([]string{"--core-instance=" + zeroUUID4, "--last=2"})
 		cmd.SetOutput(got)
 
 		err := cmd.Execute()
@@ -109,7 +109,7 @@ func Test_newCmdGetResourceProfiles(t *testing.T) {
 
 		t.Run("with_ids", func(t *testing.T) {
 			got.Reset()
-			cmd.SetArgs([]string{"--core_instance=" + zeroUUID4, "--show-ids"})
+			cmd.SetArgs([]string{"--core-instance=" + zeroUUID4, "--show-ids"})
 
 			err := cmd.Execute()
 			wantEq(t, nil, err)
@@ -124,7 +124,7 @@ func Test_newCmdGetResourceProfiles(t *testing.T) {
 			wantEq(t, nil, err)
 
 			got.Reset()
-			cmd.SetArgs([]string{"--core_instance=" + zeroUUID4, "--output-format=json"})
+			cmd.SetArgs([]string{"--core-instance=" + zeroUUID4, "--output-format=json"})
 
 			err = cmd.Execute()
 			wantEq(t, nil, err)


### PR DESCRIPTION
* First level objects such as ingest_checks or core_instance should be underscored.
* Parameters should be - separated.

Signed-off-by: Jorge Niedbalski <j@calyptia.com>
