### PR TITLE
Moves keyring stuffs to a package to save data locally

### DIFF
--- a/cmd/calyptia/auth.go
+++ b/cmd/calyptia/auth.go
@@ -6,100 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
-	"os"
-	"path/filepath"
-
-	"github.com/zalando/go-keyring"
 )
 
 const serviceName = "cloud.calyptia.com"
+const backUpFolder = ".calyptia"
 
-var (
-	errTokenNotFound = errors.New("token not found")
-	errInvalidToken  = errors.New("invalid token")
-)
-
-func saveToken(token string) error {
-	err := keyring.Set(serviceName, "project_token", token)
-	if err == nil {
-		return nil
-	}
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("could not get user home dir: %w", err)
-	}
-
-	fileName := filepath.Join(home, ".calyptia", "project_token")
-	if _, err := os.Stat(fileName); os.IsNotExist(err) {
-		dir := filepath.Dir(fileName)
-		err = os.MkdirAll(dir, fs.ModePerm)
-		if err != nil {
-			return fmt.Errorf("could not create directory %q: %w", dir, err)
-		}
-	}
-
-	err = os.WriteFile(fileName, []byte(token), fs.ModePerm)
-	if err != nil {
-		return fmt.Errorf("could not store file %q: %w", fileName, err)
-	}
-
-	return nil
-}
-
-func savedToken() (string, error) {
-	token, err := keyring.Get(serviceName, "project_token")
-	if err == keyring.ErrNotFound {
-		return "", errTokenNotFound
-	}
-
-	if err == nil {
-		return token, nil
-	}
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("could not get user home dir: %w", err)
-	}
-
-	b, err := readFile(filepath.Join(home, ".calyptia", "project_token"))
-	if errors.Is(err, fs.ErrNotExist) {
-		return "", errTokenNotFound
-	}
-
-	if err != nil {
-		return "", err
-	}
-
-	token = string(b)
-
-	return token, nil
-}
-
-func deleteSavedToken() error {
-	err := keyring.Delete(serviceName, "project_token")
-	if err == nil {
-		return nil
-	}
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-
-	fileName := filepath.Join(home, ".calyptia", "project_token")
-	if _, err := os.Stat(fileName); os.IsNotExist(err) {
-		return nil
-	}
-
-	err = os.Remove(fileName)
-	if err != nil {
-		return fmt.Errorf("could not delete default project token: %w", err)
-	}
-
-	return nil
-}
+var errInvalidToken = errors.New("invalid token")
 
 type projectTokenPayload struct {
 	ProjectID string // no json tag

--- a/cmd/calyptia/config_token.go
+++ b/cmd/calyptia/config_token.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const KeyToken = "project_token"
+
 func newCmdConfigSetToken(config *config) *cobra.Command {
 	return &cobra.Command{
 		Use:   "set_token TOKEN",
@@ -18,7 +20,7 @@ func newCmdConfigSetToken(config *config) *cobra.Command {
 				return err
 			}
 
-			return saveToken(token)
+			return config.localData.Save(KeyToken, token)
 		},
 	}
 }
@@ -39,7 +41,7 @@ func newCmdConfigUnsetToken(config *config) *cobra.Command {
 		Use:   "unset_token",
 		Short: "Unset the current configured default project token",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return deleteSavedToken()
+			return config.localData.Delete(KeyToken)
 		},
 	}
 }

--- a/cmd/calyptia/config_url.go
+++ b/cmd/calyptia/config_url.go
@@ -3,16 +3,14 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/fs"
 	"net/url"
-	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"github.com/zalando/go-keyring"
 )
 
 var errURLNotFound = errors.New("url not found")
+
+const KeyBaseURL = "base_url"
 
 func newCmdConfigSetURL(config *config) *cobra.Command {
 	return &cobra.Command{
@@ -29,7 +27,7 @@ func newCmdConfigSetURL(config *config) *cobra.Command {
 				return fmt.Errorf("invalid cloud url scheme %q", cloudURL.Scheme)
 			}
 
-			err = saveURL(cloudURL.String())
+			err = config.localData.Save(KeyBaseURL, cloudURL.String())
 			if err != nil {
 				return err
 			}
@@ -57,7 +55,7 @@ func newCmdConfigUnsetURL(config *config) *cobra.Command {
 		Use:   "unset_url",
 		Short: "Unset the current configured default cloud URL",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := deleteSavedURL()
+			err := config.localData.Delete(KeyBaseURL)
 			if err != nil {
 				return err
 			}
@@ -65,85 +63,4 @@ func newCmdConfigUnsetURL(config *config) *cobra.Command {
 			return nil
 		},
 	}
-}
-
-func saveURL(url string) error {
-	err := keyring.Set(serviceName, "base_url", url)
-	if err == nil {
-		return nil
-	}
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("could not get user home dir: %w", err)
-	}
-
-	fileName := filepath.Join(home, ".calyptia", "base_url")
-	if _, err := os.Stat(fileName); os.IsNotExist(err) {
-		dir := filepath.Dir(fileName)
-		err = os.MkdirAll(dir, fs.ModePerm)
-		if err != nil {
-			return fmt.Errorf("could not create directory %q: %w", dir, err)
-		}
-	}
-
-	err = os.WriteFile(fileName, []byte(url), fs.ModePerm)
-	if err != nil {
-		return fmt.Errorf("could not store file %q: %w", fileName, err)
-	}
-
-	return nil
-}
-
-func deleteSavedURL() error {
-	err := keyring.Delete(serviceName, "base_url")
-	if err == nil {
-		return nil
-	}
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-
-	fileName := filepath.Join(home, ".calyptia", "base_url")
-	if _, err := os.Stat(fileName); os.IsNotExist(err) {
-		return nil
-	}
-
-	err = os.Remove(fileName)
-	if err != nil {
-		return fmt.Errorf("could not delete default project url: %w", err)
-	}
-
-	return nil
-}
-
-func savedURL() (string, error) {
-	url, err := keyring.Get(serviceName, "base_url")
-	if err == keyring.ErrNotFound {
-		return "", errURLNotFound
-	}
-
-	if err == nil {
-		return url, nil
-	}
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("could not get user home dir: %w", err)
-	}
-
-	b, err := readFile(filepath.Join(home, ".calyptia", "base_url"))
-	if errors.Is(err, fs.ErrNotExist) {
-		return "", errURLNotFound
-	}
-
-	if err != nil {
-		return "", err
-	}
-
-	url = string(b)
-
-	return url, nil
 }

--- a/cmd/calyptia/main.go
+++ b/cmd/calyptia/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/calyptia/cli/localdata"
 	"net/http"
 	"net/url"
 	"os"
@@ -29,18 +30,20 @@ func newCmd(ctx context.Context) *cobra.Command {
 	client := &cloudclient.Client{
 		Client: http.DefaultClient,
 	}
+	localData := localdata.New(serviceName, backUpFolder)
 	config := &config{
-		ctx:   ctx,
-		cloud: client,
+		ctx:       ctx,
+		cloud:     client,
+		localData: localData,
 	}
 
-	token, err := savedToken()
-	if err != nil && err != errTokenNotFound {
+	token, err := localData.Get(KeyToken)
+	if err != nil && err != localdata.ErrNotFound {
 		cobra.CheckErr(fmt.Errorf("could not retrive your stored token: %w", err))
 	}
 
-	cloudURLStr, err := savedURL()
-	if err != nil && err != errURLNotFound {
+	cloudURLStr, err := localData.Get(KeyBaseURL)
+	if err != nil && err != localdata.ErrNotFound {
 		cobra.CheckErr(fmt.Errorf("could not retrive your stored url: %w", err))
 	}
 
@@ -106,6 +109,7 @@ type config struct {
 	cloud        Client
 	projectToken string
 	projectID    string
+	localData    *localdata.Keyring
 }
 
 func env(key, fallback string) string {

--- a/localdata/keyring.go
+++ b/localdata/keyring.go
@@ -1,0 +1,141 @@
+// Package local_data provides a keyring implementation that stores data in the system keyring.
+// If the keyring is not available, it falls back to storing the data in a file.
+package localdata
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	kr "github.com/zalando/go-keyring"
+)
+
+// ErrNotFound is the expected error if the data isn't found in the keyring or in the file.
+var ErrNotFound = errors.New("data not found")
+
+type Keyring struct {
+	serviceName string
+	backupFile  string
+}
+
+// New creates a new keyring.
+// serviceName is the name of the service that will be used to store the data.
+// backupFile is the name of the file that will be used to store the data if the keyring is not available.
+// The file is stored in the user's home directory, in a file named after the key.
+func New(serviceName, backupFile string) *Keyring {
+	return &Keyring{serviceName: serviceName, backupFile: backupFile}
+}
+
+// Save stores the data in the keyring.
+// If the keyring is not available, it falls back to storing the data in a file.
+// The file is stored in the user's home directory, in a file named after the key.
+func (k *Keyring) Save(key, data string) error {
+	err := kr.Set(k.serviceName, key, data)
+	if err == nil {
+		return nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("could not get user home dir: %w", err)
+	}
+
+	fileName := filepath.Join(home, k.backupFile, key)
+	if _, err := os.Stat(fileName); os.IsNotExist(err) {
+		dir := filepath.Dir(fileName)
+		err = os.MkdirAll(dir, fs.ModePerm)
+		if err != nil {
+			return fmt.Errorf("could not create directory %q: %w", dir, err)
+		}
+	}
+
+	err = os.WriteFile(fileName, []byte(data), fs.ModePerm)
+	if err != nil {
+		return fmt.Errorf("could not store file %q: %w", fileName, err)
+	}
+
+	return nil
+}
+
+// Get retrieves the data from the keyring.
+// If the keyring is not available, it falls back to retrieving the data from a file.
+func (k *Keyring) Get(key string) (string, error) {
+	data, err := kr.Get(k.serviceName, key)
+	if err == kr.ErrNotFound {
+		return "", ErrNotFound
+	}
+
+	if err == nil {
+		return data, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("could not get user home dir: %w", err)
+	}
+
+	b, err := readFile(filepath.Join(home, k.backupFile, key))
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", ErrNotFound
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	data = string(b)
+
+	return data, nil
+}
+
+// Delete removes the data from the keyring.
+// If the keyring is not available, it falls back to removing the data from a file.
+func (k *Keyring) Delete(key string) error {
+	err := kr.Delete(k.serviceName, key)
+	if err == nil {
+		return nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	fileName := filepath.Join(home, k.backupFile, key)
+	_, err = os.Stat(fileName)
+
+	if errors.Is(err, fs.ErrNotExist) {
+		return ErrNotFound
+	}
+
+	err = os.Remove(fileName)
+	if err != nil {
+		return fmt.Errorf("could not remove file %q: %w", fileName, err)
+	}
+
+	return nil
+}
+
+func readFile(name string) ([]byte, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return nil, fmt.Errorf("could not open file: %w", err)
+	}
+
+	defer func(f *os.File) {
+		err := f.Close()
+		if err != nil {
+			fmt.Printf("could not close file: %v", err)
+		}
+	}(f)
+
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("could not read contents: %w", err)
+	}
+
+	return b, nil
+}

--- a/localdata/keyring_test.go
+++ b/localdata/keyring_test.go
@@ -1,0 +1,88 @@
+package localdata
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/zalando/go-keyring"
+)
+
+func TestMain(m *testing.M) {
+	keyring.MockInit()
+	m.Run()
+}
+
+func TestKeyring(t *testing.T) {
+	t.Run("Save", func(t *testing.T) {
+		kr := New("save-test", ".backup-file")
+		err := kr.Save("key", "data")
+		if err != nil {
+			t.Fatalf("Save() error = %v", err)
+		}
+		get, err := kr.Get("key")
+		if err != nil {
+			t.Fatalf("Get() error = %v", err)
+		}
+		if get != "data" {
+			t.Errorf("Get() got = %v, want %v", get, "data")
+		}
+		err = kr.Delete("key")
+		if err != nil {
+			t.Fatalf("Delete() error = %v", err)
+		}
+	})
+	t.Run("Get", func(t *testing.T) {
+		t.Run("NotFound", func(t *testing.T) {
+			kr := New("get-test", ".backup-file")
+			get, err := kr.Get("key")
+			if !errors.Is(err, ErrNotFound) {
+				t.Fatalf("expected ErrNotFound, got %v", err)
+			}
+			if get != "" {
+				t.Errorf("Get() got = %v, want %v", get, "")
+			}
+		})
+		t.Run("Found", func(t *testing.T) {
+			kr := New("get-test", ".backup-file")
+			err := kr.Save("key", "data")
+			if err != nil {
+				t.Fatalf("Save() error = %v", err)
+			}
+			get, err := kr.Get("key")
+			if err != nil {
+				t.Fatalf("Get() error = %v", err)
+			}
+			if get != "data" {
+				t.Errorf("Get() got = %v, want %v", get, "data")
+			}
+		})
+
+	})
+	t.Run("Delete", func(t *testing.T) {
+		t.Run("NotFound", func(t *testing.T) {
+			kr := New("delete-test", ".backup-file")
+			err := kr.Delete("key")
+			if !errors.Is(err, ErrNotFound) {
+				t.Fatalf("expected ErrNotFound, got %v", err)
+			}
+		})
+		t.Run("Success", func(t *testing.T) {
+			kr := New("delete-test", ".backup-file")
+			err := kr.Save("key", "data")
+			if err != nil {
+				t.Fatalf("Save() error = %v", err)
+			}
+			err = kr.Delete("key")
+			if err != nil {
+				t.Fatalf("Delete() error = %v", err)
+			}
+			get, err := kr.Get("key")
+			if !errors.Is(err, ErrNotFound) {
+				t.Fatalf("expected ErrNotFound, got %v", err)
+			}
+			if get != "" {
+				t.Errorf("Get() got = %v, want %v", get, "")
+			}
+		})
+	})
+}


### PR DESCRIPTION
Signed-off-by: Gabriel Bussolo <gabriel@calyptia.com>

# Summary of this proposal

This PR intends to resolve #299 

Creates a package to be used to save small data.

The usability basically is `localData.Save(key, data)`, `localData.Get(key)`, `localData.Delete(key)`, it will try to save on the os keyring if its not available it will save on a local file like we were doing before, the refactor was around the usability and the code duplication, not around the functionality itself so it remains the same, just a bit **more reusable**, **documented** and with **tests**.

If it looks good for everyone it will be used on the #256 implementation also

ps: the package is `internal` to prevent imports on other projects and with it we dont need to provide support, but i put it on the `platform` package what means that one day it can be decoupled from the cli to be used by other projects. (according with package oriented design)

## Notes for the reviewer

<!-- Provide any notes that might be important for the (reviewer) of changes -->

## Issue(s) number(s)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
*Disclaimer: Please do not create a Pull Request without creating an issue first.*

## Checklist for submitter

- [x] My PR has a related issue/bug number.
- [ ] My PR provides tests
  - [ ] Integration tests are added/passes
  - [x] Unit tests are added/passes
  - [ ] End-to-end tests added/passes
  - [ ] Static code check added/passes
  - [ ] Linting on documentation added/passes
  - [ ] Does not affect code coverage stats
- [ ] My PR requires updating dependencies
- [ ] My PR has the documentation changes required.

## Checklist for reviewer

- [ ] The proposal fixes a bug/issue or implements a new feature that is well described.
- [ ] The proposal has sufficient test cases that covers the changes.
  - [ ] If changes an API, it does not break backwards compatibility (-1 major version).
- [ ] If integration is required, the proposal has integration tests.
- [ ] The proposal does not break coverage stats
- [ ] The proposal has the required documentation changes.

## Backport

<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backport to the current or earlier releases then please submit
a PR for that particular branch.
-->

- [ ] Backport to the latest stable release.