### PR TITLE
Added calyptia version subcommand

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,10 +74,10 @@ func NewRootCmd(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "calyptia",
 		Short:         "Calyptia Cloud CLI",
-		Version:       version.Version,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
+
 	cmd.SetOut(os.Stdout)
 
 	fs := cmd.PersistentFlags()
@@ -92,6 +92,7 @@ func NewRootCmd(ctx context.Context) *cobra.Command {
 		newCmdRollout(config),
 		newCmdDelete(config),
 		top.NewCmdTop(config),
+		version.NewVersionCommand(),
 	)
 
 	return cmd

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -12,7 +12,7 @@ var (
 func NewVersionCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "version",
-		Short:         "v",
+		Short:         "Returns currenty Calyptia CLI version.",
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,6 +1,26 @@
 package version
 
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
 var (
 	DefaultCloudURLStr = "https://cloud-api.calyptia.com"
 	Version            = "dev" // To be injected at build time:  -ldflags="-X 'github.com/calyptia/cli/cmd/version.Version=xxx'"
 )
+
+func NewVersionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "version",
+		Short:         "v",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("Version", Version)
+		},
+	}
+
+	return cmd
+}

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,8 +1,6 @@
 package version
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +16,7 @@ func NewVersionCommand() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("Version", Version)
+			cmd.Println(Version)
 		},
 	}
 

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -11,10 +11,9 @@ var (
 
 func NewVersionCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "version",
-		Short:         "Returns currenty Calyptia CLI version.",
-		SilenceErrors: true,
-		SilenceUsage:  true,
+		Use:          "version",
+		Short:        "Returns currenty Calyptia CLI version.",
+		SilenceUsage: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Println(Version)
 		},

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ replace github.com/calyptia/cli/k8s => ./k8s
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	github.com/Masterminds/sprig/v3 v3.2.3
-	github.com/alecthomas/assert/v2 v2.2.1
 	github.com/aws/aws-sdk-go-v2 v1.17.4
 	github.com/aws/aws-sdk-go-v2/config v1.18.13
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.86.0
@@ -43,7 +42,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
-	github.com/alecthomas/repr v0.2.0 // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.13 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.22 // indirect
@@ -76,7 +74,6 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
-	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,9 +17,7 @@ github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/assert/v2 v2.2.1 h1:XivOgYcduV98QCahG8T5XTezV5bylXe+lBxLG2K2ink=
-github.com/alecthomas/assert/v2 v2.2.1/go.mod h1:pXcQ2Asjp247dahGEmsZ6ru0UVwnkhktn7S0bBDLxvQ=
 github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk=
-github.com/alecthomas/repr v0.2.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -167,7 +165,6 @@ github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b/go.mod h1:VzxiSdG6j1p
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
-github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=


### PR DESCRIPTION
```
# calyptia version 
Version v1.0.1-23-gfdac727
```
Fixes #231 

@patrick-stephens is this what you had in mind with https://github.com/calyptia/cli/issues/231
If you prefer we can modify this maybe strip Version string and just print out actual tag. 