### PR TITLE
fleet: add get fleet command.

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -49,6 +49,7 @@ func newCmdGet(config *cfg.Config) *cobra.Command {
 		ingestcheck.NewCmdGetIngestChecks(config),
 		ingestcheck.NewCmdGetIngestCheck(config),
 		fleet.NewCmdGetFleets(config),
+		fleet.NewCmdGetFleet(config),
 	)
 
 	return cmd


### PR DESCRIPTION
# Summary of this proposal

Add the get command for fleets (single get).

## Notes for the reviewer

The one bit of weird code is the handling of the "invalid fleet name" error. This error is thrown by the server when it cannot find a fleet by the UUID.

## Issue(s) number(s)

This is related to #287.

## Checklist for submitter

- [ ] My PR has a related issue/bug number.
- [ ] My PR provides tests
  - [ ] Integration tests are added/passes
  - [ ] Unit tests are added/passes
  - [ ] End-to-end tests added/passes
  - [ ] Static code check added/passes
  - [ ] Linting on documentation added/passes
  - [ ] Does not affect code coverage stats
- [ ] My PR requires updating dependencies
- [ ] My PR has the documentation changes required.

## Checklist for reviewer

- [ ] The proposal fixes a bug/issue or implements a new feature that is well described.
- [ ] The proposal has sufficient test cases that covers the changes.
  - [ ] If changes an API, it does not break backwards compatibility (-1 major version).
- [ ] If integration is required, the proposal has integration tests.
- [ ] The proposal does not break coverage stats
- [ ] The proposal has the required documentation changes.
