### PR TITLE
Allow specifying config format for pipelines.

### DIFF
--- a/cmd/pipeline/config_format.go
+++ b/cmd/pipeline/config_format.go
@@ -8,7 +8,7 @@ import (
 
 func InferConfigFormat(configFile string) (cloud.ConfigFormat, error) {
 	switch filepath.Ext(configFile) {
-	case ".ini":
+	case ".ini", ".conf":
 		return cloud.ConfigFormatINI, nil
 	case ".yaml", ".yml":
 		return cloud.ConfigFormatYAML, nil

--- a/cmd/pipeline/config_format.go
+++ b/cmd/pipeline/config_format.go
@@ -1,0 +1,20 @@
+package pipeline
+
+import (
+	"fmt"
+	cloud "github.com/calyptia/api/types"
+	"path/filepath"
+)
+
+func InferConfigFormat(configFile string) (cloud.ConfigFormat, error) {
+	switch filepath.Ext(configFile) {
+	case ".ini":
+		return cloud.ConfigFormatINI, nil
+	case ".yaml", ".yml":
+		return cloud.ConfigFormatYAML, nil
+	case ".json":
+		return cloud.ConfigFormatJSON, nil
+	default:
+		return "", fmt.Errorf("unknown configuration file format for file: %q", configFile)
+	}
+}

--- a/cmd/pipeline/config_format_test.go
+++ b/cmd/pipeline/config_format_test.go
@@ -1,0 +1,54 @@
+package pipeline
+
+import (
+	"testing"
+
+	cloud "github.com/calyptia/api/types"
+)
+
+func TestInferConfigFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		want    cloud.ConfigFormat
+		wantErr bool
+	}{
+		{
+			name:    "INI Format",
+			file:    "config.ini",
+			want:    cloud.ConfigFormatINI,
+			wantErr: false,
+		},
+		{
+			name:    "YAML Format",
+			file:    "config.yaml",
+			want:    cloud.ConfigFormatYAML,
+			wantErr: false,
+		},
+		{
+			name:    "YML Format",
+			file:    "config.yml",
+			want:    cloud.ConfigFormatYAML,
+			wantErr: false,
+		},
+		{
+			name:    "Unrecognized Format",
+			file:    "config.txt",
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := InferConfigFormat(tt.file)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("inferConfigFormat() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("inferConfigFormat() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/pipeline/create_pipeline.go
+++ b/cmd/pipeline/create_pipeline.go
@@ -107,11 +107,22 @@ func NewCmdCreatePipeline(config *cfg.Config) *cobra.Command {
 				return err
 			}
 
+			var format cloud.ConfigFormat
+			if configFormat != "" {
+				format = cloud.ConfigFormat(configFormat)
+			} else {
+				// infer the configuration format from the file.
+				format, err = InferConfigFormat(configFile)
+				if err != nil {
+					return err
+				}
+			}
+
 			in := cloud.CreatePipeline{
 				Name:                      name,
 				ReplicasCount:             replicasCount,
 				RawConfig:                 string(rawConfig),
-				ConfigFormat:              cloud.ConfigFormat(configFormat),
+				ConfigFormat:              format,
 				Secrets:                   secrets,
 				AutoCreatePortsFromConfig: autoCreatePortsFromConfig,
 				SkipConfigValidation:      skipConfigValidation,
@@ -159,7 +170,7 @@ func NewCmdCreatePipeline(config *cfg.Config) *cobra.Command {
 	fs.StringVar(&name, "name", "", "Pipeline name; leave it empty to generate a random name")
 	fs.UintVar(&replicasCount, "replicas", 1, "Pipeline replica size")
 	fs.StringVar(&configFile, "config-file", "fluent-bit.conf", "Fluent Bit config file used by pipeline")
-	fs.StringVar(&configFormat, "config-format", string(cloud.ConfigFormatINI), "Default configuration format to use, default:INI (deprecated), will be superseded to YAML.")
+	fs.StringVar(&configFormat, "config-format", "", "Default configuration format to use (yaml, ini(deprecated))")
 	fs.StringVar(&secretsFile, "secrets-file", "", "Optional file where secrets are defined. You can store key values and reference them inside your config like so:\n{{ secrets.foo }}")
 	fs.StringVar(&secretsFormat, "secrets-format", "auto", "Secrets file format. Allowed: auto, env, json, yaml. Auto tries to detect it from file extension")
 	fs.StringArrayVar(&files, "file", nil, "Optional file. You can reference this file contents from your config like so:\n{{ files.myfile }}\nPass as many as you want; bear in mind the file name can only contain alphanumeric characters.")

--- a/cmd/pipeline/create_pipeline.go
+++ b/cmd/pipeline/create_pipeline.go
@@ -37,6 +37,8 @@ func NewCmdCreatePipeline(config *cfg.Config) *cobra.Command {
 	var metadataPairs []string
 	var metadataFile string
 	var environment string
+	var configFormat string
+
 	completer := completer.Completer{Config: config}
 
 	cmd := &cobra.Command{
@@ -109,6 +111,7 @@ func NewCmdCreatePipeline(config *cfg.Config) *cobra.Command {
 				Name:                      name,
 				ReplicasCount:             replicasCount,
 				RawConfig:                 string(rawConfig),
+				ConfigFormat:              cloud.ConfigFormat(configFormat),
 				Secrets:                   secrets,
 				AutoCreatePortsFromConfig: autoCreatePortsFromConfig,
 				SkipConfigValidation:      skipConfigValidation,
@@ -156,6 +159,7 @@ func NewCmdCreatePipeline(config *cfg.Config) *cobra.Command {
 	fs.StringVar(&name, "name", "", "Pipeline name; leave it empty to generate a random name")
 	fs.UintVar(&replicasCount, "replicas", 1, "Pipeline replica size")
 	fs.StringVar(&configFile, "config-file", "fluent-bit.conf", "Fluent Bit config file used by pipeline")
+	fs.StringVar(&configFormat, "config-format", string(cloud.ConfigFormatINI), "Default configuration format to use, default:INI (deprecated), will be superseded to YAML.")
 	fs.StringVar(&secretsFile, "secrets-file", "", "Optional file where secrets are defined. You can store key values and reference them inside your config like so:\n{{ secrets.foo }}")
 	fs.StringVar(&secretsFormat, "secrets-format", "auto", "Secrets file format. Allowed: auto, env, json, yaml. Auto tries to detect it from file extension")
 	fs.StringArrayVar(&files, "file", nil, "Optional file. You can reference this file contents from your config like so:\n{{ files.myfile }}\nPass as many as you want; bear in mind the file name can only contain alphanumeric characters.")

--- a/cmd/pipeline/create_pipeline.go
+++ b/cmd/pipeline/create_pipeline.go
@@ -37,7 +37,7 @@ func NewCmdCreatePipeline(config *cfg.Config) *cobra.Command {
 	var metadataPairs []string
 	var metadataFile string
 	var environment string
-	var configFormat string
+	var providedConfigFormat string
 
 	completer := completer.Completer{Config: config}
 
@@ -108,14 +108,17 @@ func NewCmdCreatePipeline(config *cfg.Config) *cobra.Command {
 			}
 
 			var format cloud.ConfigFormat
-			if configFormat != "" {
-				format = cloud.ConfigFormat(configFormat)
-			} else {
+
+			if providedConfigFormat != "" {
+				format = cloud.ConfigFormat(providedConfigFormat)
+			} else if configFile != "" {
 				// infer the configuration format from the file.
 				format, err = InferConfigFormat(configFile)
 				if err != nil {
 					return err
 				}
+			} else {
+				format = cloud.ConfigFormatINI
 			}
 
 			in := cloud.CreatePipeline{
@@ -170,7 +173,7 @@ func NewCmdCreatePipeline(config *cfg.Config) *cobra.Command {
 	fs.StringVar(&name, "name", "", "Pipeline name; leave it empty to generate a random name")
 	fs.UintVar(&replicasCount, "replicas", 1, "Pipeline replica size")
 	fs.StringVar(&configFile, "config-file", "fluent-bit.conf", "Fluent Bit config file used by pipeline")
-	fs.StringVar(&configFormat, "config-format", "", "Default configuration format to use (yaml, ini(deprecated))")
+	fs.StringVar(&providedConfigFormat, "config-format", "", "Default configuration format to use (yaml, ini(deprecated))")
 	fs.StringVar(&secretsFile, "secrets-file", "", "Optional file where secrets are defined. You can store key values and reference them inside your config like so:\n{{ secrets.foo }}")
 	fs.StringVar(&secretsFormat, "secrets-format", "auto", "Secrets file format. Allowed: auto, env, json, yaml. Auto tries to detect it from file extension")
 	fs.StringArrayVar(&files, "file", nil, "Optional file. You can reference this file contents from your config like so:\n{{ files.myfile }}\nPass as many as you want; bear in mind the file name can only contain alphanumeric characters.")

--- a/cmd/pipeline/update_pipeline.go
+++ b/cmd/pipeline/update_pipeline.go
@@ -34,7 +34,7 @@ func NewCmdUpdatePipeline(config *cfg.Config) *cobra.Command {
 	var outputFormat, goTemplate string
 	var metadataPairs []string
 	var metadataFile string
-	var configFormat string
+	var providedConfigFormat string
 
 	completer := completer.Completer{Config: config}
 
@@ -103,14 +103,17 @@ func NewCmdUpdatePipeline(config *cfg.Config) *cobra.Command {
 			}
 
 			var format cloud.ConfigFormat
-			if configFormat != "" {
-				format = cloud.ConfigFormat(configFormat)
-			} else {
+
+			if providedConfigFormat != "" {
+				format = cloud.ConfigFormat(providedConfigFormat)
+			} else if rawConfig != "" {
 				// infer the configuration format from the file.
-				format, err = InferConfigFormat(newConfigFile)
+				format, err = InferConfigFormat(rawConfig)
 				if err != nil {
 					return err
 				}
+			} else {
+				format = cloud.ConfigFormatINI
 			}
 
 			update := cloud.UpdatePipeline{
@@ -168,7 +171,7 @@ func NewCmdUpdatePipeline(config *cfg.Config) *cobra.Command {
 	fs := cmd.Flags()
 	fs.StringVar(&newName, "new-name", "", "New pipeline name")
 	fs.StringVar(&newConfigFile, "config-file", "", "New Fluent Bit config file used by pipeline")
-	fs.StringVar(&configFormat, "config-format", "", "Default configuration format to use (yaml, ini(deprecated))")
+	fs.StringVar(&providedConfigFormat, "config-format", "", "Default configuration format to use (yaml, ini(deprecated))")
 	fs.UintVar(&newReplicasCount, "replicas", 0, "New pipeline replica size")
 	fs.BoolVar(&autoCreatePortsFromConfig, "auto-create-ports", true, "Automatically create pipeline ports from config if updated")
 	fs.BoolVar(&skipConfigValidation, "skip-config-validation", false, "Opt-in to skip config validation (Use with caution as this option might be removed soon)")

--- a/cmd/pipeline/update_pipeline.go
+++ b/cmd/pipeline/update_pipeline.go
@@ -108,7 +108,7 @@ func NewCmdUpdatePipeline(config *cfg.Config) *cobra.Command {
 				format = cloud.ConfigFormat(providedConfigFormat)
 			} else if rawConfig != "" {
 				// infer the configuration format from the file.
-				format, err = InferConfigFormat(rawConfig)
+				format, err = InferConfigFormat(newConfigFile)
 				if err != nil {
 					return err
 				}

--- a/cmd/pipeline/update_pipeline.go
+++ b/cmd/pipeline/update_pipeline.go
@@ -102,10 +102,21 @@ func NewCmdUpdatePipeline(config *cfg.Config) *cobra.Command {
 				return err
 			}
 
+			var format cloud.ConfigFormat
+			if configFormat != "" {
+				format = cloud.ConfigFormat(configFormat)
+			} else {
+				// infer the configuration format from the file.
+				format, err = InferConfigFormat(newConfigFile)
+				if err != nil {
+					return err
+				}
+			}
+
 			update := cloud.UpdatePipeline{
 				AutoCreatePortsFromConfig: &autoCreatePortsFromConfig,
 				SkipConfigValidation:      skipConfigValidation,
-				ConfigFormat:              cfg.Ptr(cloud.ConfigFormat(configFormat)),
+				ConfigFormat:              &format,
 				Secrets:                   secrets,
 				Files:                     updatePipelineFiles,
 				Metadata:                  metadata,
@@ -157,7 +168,7 @@ func NewCmdUpdatePipeline(config *cfg.Config) *cobra.Command {
 	fs := cmd.Flags()
 	fs.StringVar(&newName, "new-name", "", "New pipeline name")
 	fs.StringVar(&newConfigFile, "config-file", "", "New Fluent Bit config file used by pipeline")
-	fs.StringVar(&configFormat, "config-format", string(cloud.ConfigFormatINI), "Default configuration format to use, default:INI (deprecated), will be superseded to YAML.")
+	fs.StringVar(&configFormat, "config-format", "", "Default configuration format to use (yaml, ini(deprecated))")
 	fs.UintVar(&newReplicasCount, "replicas", 0, "New pipeline replica size")
 	fs.BoolVar(&autoCreatePortsFromConfig, "auto-create-ports", true, "Automatically create pipeline ports from config if updated")
 	fs.BoolVar(&skipConfigValidation, "skip-config-validation", false, "Opt-in to skip config validation (Use with caution as this option might be removed soon)")

--- a/cmd/pipeline/update_pipeline.go
+++ b/cmd/pipeline/update_pipeline.go
@@ -34,6 +34,8 @@ func NewCmdUpdatePipeline(config *cfg.Config) *cobra.Command {
 	var outputFormat, goTemplate string
 	var metadataPairs []string
 	var metadataFile string
+	var configFormat string
+
 	completer := completer.Completer{Config: config}
 
 	cmd := &cobra.Command{
@@ -103,6 +105,7 @@ func NewCmdUpdatePipeline(config *cfg.Config) *cobra.Command {
 			update := cloud.UpdatePipeline{
 				AutoCreatePortsFromConfig: &autoCreatePortsFromConfig,
 				SkipConfigValidation:      skipConfigValidation,
+				ConfigFormat:              cfg.Ptr(cloud.ConfigFormat(configFormat)),
 				Secrets:                   secrets,
 				Files:                     updatePipelineFiles,
 				Metadata:                  metadata,
@@ -154,6 +157,7 @@ func NewCmdUpdatePipeline(config *cfg.Config) *cobra.Command {
 	fs := cmd.Flags()
 	fs.StringVar(&newName, "new-name", "", "New pipeline name")
 	fs.StringVar(&newConfigFile, "config-file", "", "New Fluent Bit config file used by pipeline")
+	fs.StringVar(&configFormat, "config-format", string(cloud.ConfigFormatINI), "Default configuration format to use, default:INI (deprecated), will be superseded to YAML.")
 	fs.UintVar(&newReplicasCount, "replicas", 0, "New pipeline replica size")
 	fs.BoolVar(&autoCreatePortsFromConfig, "auto-create-ports", true, "Automatically create pipeline ports from config if updated")
 	fs.BoolVar(&skipConfigValidation, "skip-config-validation", false, "Opt-in to skip config validation (Use with caution as this option might be removed soon)")


### PR DESCRIPTION
# Summary of this proposal

YAML will be the default in a subsequent release.
For now we keep ini (as default) and enable --config-format to create and update pipeline actions.

## Notes for the reviewer

```
cli  create pipeline test --config-file config.yaml --core-instance test-config --skip-config-validation --config-format=test
Error: could not create pipeline: invalid pipeline config format
➜ cli (config-format-v2) ✗ ./cli  create pipeline test --config-file config.yaml --core-instance test-config --skip-config-validation --config-format=yaml
ID                                   NAME               AGE
e683e3ad-edc2-4681-bdce-7cdfaa8c6075 game-gauntlet-7d79 Just now

```

then update

```
➜ cli (config-format-v2) ✗ ./cli update pipeline game-gauntlet-7d79 --config-file config.yaml --config-format=yaml
➜ cli (config-format-v2) ✗ ./cli update pipeline game-gauntlet-7d79 --config-file config.yaml --config-format=test
Error: could not update pipeline: invalid pipeline config format

```