### PR TITLE
[fix] If provided version is latest, use the latest release tag.

### DIFF
--- a/cmd/coreinstance/create_core_instance_operator.go
+++ b/cmd/coreinstance/create_core_instance_operator.go
@@ -109,8 +109,12 @@ func newCmdCreateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 				return err
 			}
 
-			fmt.Printf("Found calyptia core operator installed, version: %s...\n", operatorVersion)
+			// If the version is set to "latest", use the last registered official tag.
+			if operatorVersion == utils.LatestVersion {
+				operatorVersion = utils.DefaultCoreOperatorDockerImageTag
+			}
 
+			fmt.Printf("Found calyptia core operator installed, version: %s...\n", operatorVersion)
 			metadata, err := getCoreInstanceMetadata(k8sClient)
 			if err != nil {
 				return err

--- a/cmd/coreinstance/create_core_instance_operator.go
+++ b/cmd/coreinstance/create_core_instance_operator.go
@@ -109,11 +109,6 @@ func newCmdCreateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 				return err
 			}
 
-			// If the version is set to "latest", use the last registered official tag.
-			if operatorVersion == utils.LatestVersion {
-				operatorVersion = utils.DefaultCoreOperatorDockerImageTag
-			}
-
 			fmt.Printf("Found calyptia core operator installed, version: %s...\n", operatorVersion)
 			metadata, err := getCoreInstanceMetadata(k8sClient)
 			if err != nil {
@@ -128,7 +123,12 @@ func newCmdCreateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 				Tags:                   tags,
 				SkipServiceCreation:    skipServiceCreation,
 				Metadata:               metadata,
-				Version:                operatorVersion,
+			}
+
+			// If version is set to != latest, use the provided version, otherwise
+			// let it be the default value.
+			if operatorVersion != utils.LatestVersion {
+				coreInstanceParams.Version = operatorVersion
 			}
 
 			if coreFluentBitDockerImage != "" {

--- a/cmd/coreinstance/create_core_instance_operator.go
+++ b/cmd/coreinstance/create_core_instance_operator.go
@@ -125,8 +125,8 @@ func newCmdCreateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 				Metadata:               metadata,
 			}
 
-			// If version is set to != latest, use the provided version, otherwise
-			// let it be the default value.
+			// Only set the version if != latest, otherwise use the default value
+			// for registering this core instance.
 			if operatorVersion != utils.LatestVersion {
 				coreInstanceParams.Version = operatorVersion
 			}

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
+	LatestVersion = "latest"
 	//nolint: gosec // this is not a secret leak, it's just a format declaration.
 	DefaultCoreDockerImage    = "ghcr.io/calyptia/core"
-	DefaultCoreDockerImageTag = "latest"
+	DefaultCoreDockerImageTag = LatestVersion
 
 	DefaultCoreOperatorDockerImage = "ghcr.io/calyptia/core-operator"
 	// DefaultCoreOperatorDockerImageTag not manually modified, CI should switch this version on every new release.


### PR DESCRIPTION
# Summary of this proposal

If the provided version is latest, use the last released tag instead when
registering the core_instance.

