### PR TITLE
install/operator: allow installing to namespaces that already exist.

### DIFF
--- a/cmd/operator/install.go
+++ b/cmd/operator/install.go
@@ -70,7 +70,7 @@ func NewCmdInstall() *cobra.Command {
 				Interface: clientSet,
 			}
 			_, err = k.GetNamespace(context.Background(), namespace)
-			if !k8serrors.IsNotFound(err) {
+			if err != nil && !k8serrors.IsNotFound(err) {
 				return err
 			}
 


### PR DESCRIPTION
# Summary of this proposal

Allow using namespaces that already exist. I suppose the intent here was to allow creating operators in new namespaces but not in ones we cannot list.

## Notes for the reviewer

A pretty quick change.

## Checklist for submitter

- [ ] My PR has a related issue/bug number.
- [ ] My PR provides tests
  - [ ] Integration tests are added/passes
  - [ ] Unit tests are added/passes
  - [ ] End-to-end tests added/passes
  - [ ] Static code check added/passes
  - [ ] Linting on documentation added/passes
  - [ ] Does not affect code coverage stats
- [ ] My PR requires updating dependencies
- [ ] My PR has the documentation changes required.

## Checklist for reviewer

- [ ] The proposal fixes a bug/issue or implements a new feature that is well described.
- [ ] The proposal has sufficient test cases that covers the changes.
  - [ ] If changes an API, it does not break backwards compatibility (-1 major version).
- [ ] If integration is required, the proposal has integration tests.
- [ ] The proposal does not break coverage stats
- [ ] The proposal has the required documentation changes.

## Backport

<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backport to the current or earlier releases then please submit
a PR for that particular branch.
-->

- [ ] Backport to the latest stable release.