### PR TITLE
completer: fix get fleet by id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /cli
 /fluent-bit.conf
+/fluent-bit.yaml
 .idea/
 /calyptia
 gha-creds-*.json

--- a/completer/completer.go
+++ b/completer/completer.go
@@ -514,6 +514,10 @@ func (c *Completer) LoadFleetID(key string) (string, error) {
 		Last:      config.Ptr(uint(1)),
 	})
 	if err != nil {
+		if strings.Contains(err.Error(), "invalid fleet name") && config.ValidUUID(key) {
+			return key, nil
+		}
+
 		return "", err
 	}
 


### PR DESCRIPTION
Fixed an error while trying to fetch a fleet given its ID it would try to search it by name first and would error with `invalid fleet name`.

See https://app.asana.com/0/1203043924955727/1205089761290682