### PR TITLE
Disable CGO at build time entirely.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,8 @@ blobs:
 builds:
   - main: .
     id: calyptia
+    env:
+      - CGO_ENABLED=0
     binary: calyptia
     ldflags:
       - -s -w -X github.com/calyptia/cli/cmd/version.Version={{.Version}}


### PR DESCRIPTION
Follow suit on https://tip.golang.org/doc/go1.20 and disable CGO entirely (not required) here.

Recompiled and tested with

```
[root@centos-niedbalski jorge]# ldd --version | grep -i libc
ldd (GNU libc) 2.17
[root@centos-niedbalski jorge]# ./calyptia
Calyptia Cloud CLI
Usage:
  calyptia [command]
Available Commands:
  completion  Generate the autocompletion script for the specified shell
  config      Configure Calyptia CLI
  create      Create core instances, pipelines, etc.
  delete      Delete core instances, pipelines, etc.
  get         Display one or many resources
  help        Help about any command
  install     Install calyptia components
  rollout     Rollout resources to previous versions
  top         Display metrics
  uninstall   Uninstall calyptia components
  update      Update core instances, pipelines, etc.
  version     Returns currenty Calyptia CLI version.
Flags:
      --cloud-url string   Calyptia Cloud URL (default “https://cloud-api.calyptia.com/”)
  -h, --help               help for calyptia
      --token string       Calyptia Cloud Project token (default “check with the ‘calyptia config current_token’ command”)
Use “calyptia [command] --help” for more information about a command.
[root@centos-niedbalski jorge]#

[root@centos-niedbalski jorge]# ldd calyptia 
        not a dynamic executable
[root@centos-niedbalski jorge]# more /etc/centos-release
CentOS Linux release 7.9.2009 (Core)

```
