### PR TITLE
[Fix] core_instance install 

### DIFF
--- a/cmd/operator/install.go
+++ b/cmd/operator/install.go
@@ -4,11 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+
 	"github.com/calyptia/cli/cmd/utils"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"strconv"
+
+	"os"
+	"regexp"
+	"strings"
 
 	"github.com/calyptia/cli/k8s"
 	"github.com/spf13/cobra"
@@ -17,9 +22,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/component-base/logs"
 	kubectl "k8s.io/kubectl/pkg/cmd"
-	"os"
-	"regexp"
-	"strings"
 )
 
 func NewCmdInstall() *cobra.Command {
@@ -72,7 +74,6 @@ func NewCmdInstall() *cobra.Command {
 			if err != nil && !k8serrors.IsNotFound(err) {
 				return err
 			}
-
 			yaml, err := prepareInstallManifest(coreDockerImage, coreInstanceVersion, namespace, k8serrors.IsNotFound(err))
 			if err != nil {
 				return err

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -20,15 +20,15 @@ const (
 
 	DefaultCoreOperatorDockerImage = "ghcr.io/calyptia/core-operator"
 	// DefaultCoreOperatorDockerImageTag not manually modified, CI should switch this version on every new release.
-	DefaultCoreOperatorDockerImageTag = "1.0.9"
+	DefaultCoreOperatorDockerImageTag = "v1.0.9"
 
 	DefaultCoreOperatorToCloudDockerImage = "ghcr.io/calyptia/core-operator/sync-to-cloud"
 	// DefaultCoreOperatorToCloudDockerImageTag not manually modified, CI should switch this version on every new release.
-	DefaultCoreOperatorToCloudDockerImageTag = "1.0.9"
+	DefaultCoreOperatorToCloudDockerImageTag = "v1.0.9"
 
 	DefaultCoreOperatorFromCloudDockerImage = "ghcr.io/calyptia/core-operator/sync-from-cloud"
 	// DefaultCoreOperatorFromCloudDockerImageTag not manually modified, CI should switch this version on every new release.
-	DefaultCoreOperatorFromCloudDockerImageTag = "1.0.9"
+	DefaultCoreOperatorFromCloudDockerImageTag = "v1.0.9"
 )
 
 type RecordCell struct {


### PR DESCRIPTION
add to sync deployment metrics_port, as well extended parameters for … core_instance install with --metrics-port

```
 --metrics-port string                 Port for metrics endpoint. (default "15334")
```

Important changes:

* `calyptia-core-controller-manager` - operator deployment name has changed for sake of better readability https://github.com/calyptia/core-operator/blob/main/config/default/kustomization.yaml#L4
* versions which were updated by the CI were in incorrect format 1.0.9 vs v1.0.9