### PR TITLE
Fixes user home dir unavailable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ calyptia get members --token TOKEN
 
 ---
 
+## Environment variables
+
+A list of the supported environment variables that will override the provided flags.
+
+- CALYPTIA_CLOUD_URL: URL of the cloud API (default: https://cloud-api.calyptia.com/)
+- CALYPTIA_CLOUD_TOKEN: Cloud project token (default: None)
+- CALYPTIA_STORAGE_DIR: Path to store the local configuration (fallback to $HOME/.calyptia)
+
 ## Commands
 
 ```bash

--- a/localdata/keyring.go
+++ b/localdata/keyring.go
@@ -38,12 +38,7 @@ func (k *Keyring) Save(key, data string) error {
 		return nil
 	}
 
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("could not get user home dir: %w", err)
-	}
-
-	fileName := filepath.Join(home, k.backupFile, key)
+	fileName := filepath.Join(k.backupFile, key)
 	if _, err := os.Stat(fileName); os.IsNotExist(err) {
 		dir := filepath.Dir(fileName)
 		err = os.MkdirAll(dir, fs.ModePerm)
@@ -72,12 +67,7 @@ func (k *Keyring) Get(key string) (string, error) {
 		return data, nil
 	}
 
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("could not get user home dir: %w", err)
-	}
-
-	b, err := readFile(filepath.Join(home, k.backupFile, key))
+	b, err := readFile(filepath.Join(k.backupFile, key))
 	if errors.Is(err, fs.ErrNotExist) {
 		return "", ErrNotFound
 	}
@@ -99,12 +89,7 @@ func (k *Keyring) Delete(key string) error {
 		return nil
 	}
 
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-
-	fileName := filepath.Join(home, k.backupFile, key)
+	fileName := filepath.Join(k.backupFile, key)
 	_, err = os.Stat(fileName)
 
 	if errors.Is(err, fs.ErrNotExist) {


### PR DESCRIPTION
# Summary of this proposal

Enables CALYPTIA_STORAGE_DIR, if not provided will fallback to $HOME/.calyptia (current default).
If no home is available && no CALYPTIA_STORAGE_DIR its a failure. 

## Asana task(s) link.

Related to https://app.asana.com/0/1205042382663691/1205181919631508/

