### PR TITLE
Use namespace parameter from kube-* flags

### DIFF
--- a/cmd/operator/install.go
+++ b/cmd/operator/install.go
@@ -40,7 +40,7 @@ func NewCmdInstall() *cobra.Command {
 		Short:   "Setup a new core operator instance",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			kctl := newKubectlCmd()
-			namespace := cmd.Flag("namespace").Value.String()
+			namespace := cmd.Flag("kube-namespace").Value.String()
 			if namespace == "" {
 				namespace = apiv1.NamespaceDefault
 			}

--- a/cmd/operator/uninstall.go
+++ b/cmd/operator/uninstall.go
@@ -22,7 +22,7 @@ func NewCmdUninstall() *cobra.Command {
 		Short:   "Uninstall operator components",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			kctl := newKubectlCmd()
-			namespace := cmd.Flag("namespace").Value.String()
+			namespace := cmd.Flag("kube-namespace").Value.String()
 			kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 			kubeClientConfig, err := kubeConfig.ClientConfig()
 			if err != nil {


### PR DESCRIPTION
# Summary of this proposal

Force the parameter to be inferred from kube-flags and not from local flags. 
Also note that I will re-instante unit-tests for CLI in a follow-up PR.

## Asana task(s) link.

N/A.

## Notes for the reviewer

N/A

