### PR TITLE
injecting cluster name into core-instance metadata

### DIFF
--- a/cmd/coreinstance/create_core_instance_operator.go
+++ b/cmd/coreinstance/create_core_instance_operator.go
@@ -123,6 +123,11 @@ func newCmdCreateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 				return err
 			}
 
+			metadata.ClusterName, err = getClusterName()
+			if err != nil {
+				return err
+			}
+
 			coreInstanceParams := cloud.CreateCoreInstance{
 				Name:                   coreInstanceName,
 				AddHealthCheckPipeline: !noHealthCheckPipeline,
@@ -345,4 +350,19 @@ func getCoreInstanceMetadata(k8s *k8s.Client) (cloud.CoreInstanceMetadata, error
 	metadata.ClusterPlatform = info.Platform
 
 	return metadata, nil
+}
+
+func getClusterName() (string, error) {
+	var err error
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	rawKubeConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{}).RawConfig()
+	if err != nil {
+		return "", err
+	}
+	clusterName := rawKubeConfig.CurrentContext
+	if clusterName == "" {
+		clusterName = "default"
+	}
+
+	return clusterName, nil
 }


### PR DESCRIPTION
# Summary of this proposal

Fetch  clusterName from Kubeconfig and inject it into core instance metadata in Cloud API

## Asana task(s) link.

https://app.asana.com/0/1205042382663688/1205090901467155/f

## Notes for the reviewer

For inCluster Kubeconfig currentContext is usually an empty string so in that case to override that i'm injecting value "default"


