### PR TITLE
workflows: switch to non-on-prem version of e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Checkoout cloud-e2e
+      - name: Checkout cloud-e2e
         uses: actions/checkout@v3
         with:
           repository: calyptia/cloud-e2e
           token: ${{ secrets.CI_PAT }}
-          ref: "main"
+          ref: "v1.1.0"
           path: cloud-e2e
 
       - name: Log in to the Container registry
@@ -81,7 +81,7 @@ jobs:
       - name: Setup BATS
         uses: mig4/setup-bats@v1
         with:
-          bats-version: 1.7.0
+          bats-version: 1.9.0
 
       - name: Load required images in the kind cluster
         run: |


### PR DESCRIPTION
# Summary of this proposal

Small change to use the old version of e2e testing just to ensure it works for now.
Will be switching to latest with #535 

## Asana task(s) link.

<!--- Mandatory: Please provide the related asana task(s) -->

## Notes for the reviewer

No change here really, primarily is to unblock any future releases.

