### PR TITLE
Check version before updating

### DIFF
--- a/cmd/coreinstance/update_core_instance_operator.go
+++ b/cmd/coreinstance/update_core_instance_operator.go
@@ -16,7 +16,6 @@ import (
 	cfg "github.com/calyptia/cli/config"
 	"github.com/calyptia/cli/k8s"
 	"github.com/calyptia/core-images-index/go-index"
-	semver "github.com/hashicorp/go-version"
 )
 
 func NewCmdUpdateCoreInstanceOperator(config *cfg.Config, testClientSet kubernetes.Interface) *cobra.Command {
@@ -42,32 +41,15 @@ func NewCmdUpdateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 			if !strings.HasPrefix(newVersion, "v") {
 				newVersion = fmt.Sprintf("v%s", newVersion)
 			}
-			if _, err := semver.NewSemver(newVersion); err != nil {
-				return err
-			}
-
 			containerIndex, err := index.NewContainer()
 			if err != nil {
 				return err
 			}
 
-			indices, err := containerIndex.All(cmd.Context())
+			_, err = containerIndex.Match(cmd.Context(), newVersion)
 			if err != nil {
 				return err
 			}
-
-			var found bool
-			for _, index := range indices {
-				found = index == newVersion
-				if found {
-					break
-				}
-			}
-
-			if !found {
-				return fmt.Errorf("%s version is not available", newVersion)
-			}
-
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/coreinstance/update_core_instance_operator.go
+++ b/cmd/coreinstance/update_core_instance_operator.go
@@ -41,14 +41,14 @@ func NewCmdUpdateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 			if !strings.HasPrefix(newVersion, "v") {
 				newVersion = fmt.Sprintf("v%s", newVersion)
 			}
-			containerIndex, err := index.NewContainer()
+			operatorIndex, err := index.NewOperator()
 			if err != nil {
 				return err
 			}
 
-			_, err = containerIndex.Match(cmd.Context(), newVersion)
+			_, err = operatorIndex.Match(cmd.Context(), newVersion)
 			if err != nil {
-				return err
+				return fmt.Errorf("core_instance image tag %s is not available", newVersion)
 			}
 			return nil
 		},
@@ -167,7 +167,7 @@ func NewCmdUpdateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 	fs.BoolVar(&skipServiceCreation, "skip-service-creation", false, "Skip the creation of kubernetes services for any pipeline under this core instance.")
 
 	_ = cmd.RegisterFlagCompletionFunc("environment", completer.CompleteEnvironments)
-	_ = cmd.RegisterFlagCompletionFunc("version", completer.CompleteCoreContainerVersion)
+	_ = cmd.RegisterFlagCompletionFunc("version", completer.CompleteCoreOperatorVersion)
 	clientcmd.BindOverrideFlags(configOverrides, fs, clientcmd.RecommendedConfigOverrideFlags("kube-"))
 	return cmd
 }

--- a/cmd/coreinstance/update_core_instance_operator.go
+++ b/cmd/coreinstance/update_core_instance_operator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/calyptia/cli/completer"
 	cfg "github.com/calyptia/cli/config"
 	"github.com/calyptia/cli/k8s"
+	"github.com/calyptia/core-images-index/go-index"
 	semver "github.com/hashicorp/go-version"
 )
 
@@ -44,6 +45,29 @@ func NewCmdUpdateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 			if _, err := semver.NewSemver(newVersion); err != nil {
 				return err
 			}
+
+			containerIndex, err := index.NewContainer()
+			if err != nil {
+				return err
+			}
+
+			indices, err := containerIndex.All(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			var found bool
+			for _, index := range indices {
+				found = index == newVersion
+				if found {
+					break
+				}
+			}
+
+			if !found {
+				return fmt.Errorf("%s version is not available", newVersion)
+			}
+
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/operator/update.go
+++ b/cmd/operator/update.go
@@ -42,21 +42,9 @@ func NewCmdUpdate() *cobra.Command {
 				return err
 			}
 
-			indices, err := containerIndex.All(cmd.Context())
+			_, err = containerIndex.Match(cmd.Context(), coreOperatorVersion)
 			if err != nil {
 				return err
-			}
-
-			var found bool
-			for _, index := range indices {
-				found = index == coreOperatorVersion
-				if found {
-					break
-				}
-			}
-
-			if !found {
-				return fmt.Errorf("%s version is not available", coreOperatorVersion)
 			}
 			return nil
 		},

--- a/cmd/operator/update.go
+++ b/cmd/operator/update.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/calyptia/cli/cmd/utils"
+	"github.com/calyptia/core-images-index/go-index"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -34,6 +35,28 @@ func NewCmdUpdate() *cobra.Command {
 			}
 			if _, err := semver.NewSemver(coreOperatorVersion); err != nil {
 				return err
+			}
+
+			containerIndex, err := index.NewContainer()
+			if err != nil {
+				return err
+			}
+
+			indices, err := containerIndex.All(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			var found bool
+			for _, index := range indices {
+				found = index == coreOperatorVersion
+				if found {
+					break
+				}
+			}
+
+			if !found {
+				return fmt.Errorf("%s version is not available", coreOperatorVersion)
 			}
 			return nil
 		},

--- a/cmd/operator/update.go
+++ b/cmd/operator/update.go
@@ -37,14 +37,14 @@ func NewCmdUpdate() *cobra.Command {
 				return err
 			}
 
-			containerIndex, err := index.NewContainer()
+			operatorIndex, err := index.NewOperator()
 			if err != nil {
 				return err
 			}
 
-			_, err = containerIndex.Match(cmd.Context(), coreOperatorVersion)
+			_, err = operatorIndex.Match(cmd.Context(), coreOperatorVersion)
 			if err != nil {
-				return err
+				return fmt.Errorf("core-operator image tag %s is not available", coreOperatorVersion)
 			}
 			return nil
 		},

--- a/completer/completer.go
+++ b/completer/completer.go
@@ -178,6 +178,20 @@ func (c *Completer) CompleteCoreContainerVersion(cmd *cobra.Command, args []stri
 	return vv, cobra.ShellCompDirectiveNoFileComp
 }
 
+func (c *Completer) CompleteCoreOperatorVersion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	operatorIndex, err := index.NewOperator()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	vv, err := operatorIndex.All(c.Config.Ctx)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	return vv, cobra.ShellCompDirectiveNoFileComp
+}
+
 func (c *Completer) CompletePipelines(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	pp, err := c.FetchAllPipelines()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.15.5
 	github.com/calyptia/api v1.3.2
 	github.com/calyptia/cli/k8s v0.0.0-20230824165254-bdb6c15160d6
-	github.com/calyptia/core-images-index/go-index v0.0.0-20230824152146-76a802fcc2ef
+	github.com/calyptia/core-images-index/go-index v0.0.0-20230831205126-d2594da758bd
 	github.com/calyptia/go-bubble-table v0.2.1
 	github.com/calyptia/go-fluentbit-config/v2 v2.0.0
 	github.com/charmbracelet/bubbletea v0.24.2

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/calyptia/cli/k8s v0.0.0-20230824165254-bdb6c15160d6 h1:kzcm/sLIx8piaY
 github.com/calyptia/cli/k8s v0.0.0-20230824165254-bdb6c15160d6/go.mod h1:CvkWcv3I814qVOVkP/UqJEy3wf3lF6Tss8/OFDEflDQ=
 github.com/calyptia/core-images-index/go-index v0.0.0-20230824152146-76a802fcc2ef h1:03BtrXqVORHYOO5YleH6DFnCUVNNnzDPBE3mRnjdh/U=
 github.com/calyptia/core-images-index/go-index v0.0.0-20230824152146-76a802fcc2ef/go.mod h1:9+aUlL+o9dpq2wcF4CLEQlPAcjlmuwohVRvOxNN6TWk=
+github.com/calyptia/core-images-index/go-index v0.0.0-20230831205126-d2594da758bd h1:RAzlEO/caxj2yXDMkpXtphkDsvSs3ALhThFFykWZg4o=
+github.com/calyptia/core-images-index/go-index v0.0.0-20230831205126-d2594da758bd/go.mod h1:9+aUlL+o9dpq2wcF4CLEQlPAcjlmuwohVRvOxNN6TWk=
 github.com/calyptia/go-bubble-table v0.2.1 h1:NWcVRyGCLuP7QIA29uUFSY+IjmWcmUWHjy5J/CPb0Rk=
 github.com/calyptia/go-bubble-table v0.2.1/go.mod h1:gJvzUOUzfQeA9JmgLumyJYWJMtuRQ7WxxTwc9tjEiGw=
 github.com/calyptia/go-fluentbit-config/v2 v2.0.0 h1:2o7qZEbpLX0b+kn3F/+X/RiN/oRw8lDqJKXM5tWSLKg=


### PR DESCRIPTION
# Summary of this proposal

Check version before allowing CLI to update operator or core-instance 

## Asana task(s) link.

https://app.asana.com/0/1205296323611471/1205392234116840

## Notes for the reviewer

This is relying on "github.com/calyptia/core-images-index/go-index" that is reading from https://github.com/calyptia/core-images-index/blob/main/container.index.json which is currently incomplete. 


```
# ./calyptia  update operator  --version v123
Error: v123 version is not available
```

```
# ./calyptia  update core_instance operator careful-princess-b852d --version v123
Error: v123 version is not available
```