### PR TITLE
Enable config formats for pipeline/s retrieval.

### DIFF
--- a/cmd/pipeline/get_pipeline.go
+++ b/cmd/pipeline/get_pipeline.go
@@ -19,10 +19,11 @@ import (
 func NewCmdGetPipelines(config *cfg.Config) *cobra.Command {
 	var coreInstanceKey string
 	var last uint
-	var outputFormat, goTemplate string
+	var outputFormat, goTemplate, configFormat string
 	var showIDs bool
 	var environment string
 	var renderWithConfigSections bool
+
 	completer := completer.Completer{Config: config}
 
 	cmd := &cobra.Command{
@@ -42,10 +43,16 @@ func NewCmdGetPipelines(config *cfg.Config) *cobra.Command {
 				return err
 			}
 
+			if configFormat != "" {
+				if !isValidConfigFormat(configFormat) {
+					return fmt.Errorf("not a valid config format: %s", configFormat)
+				}
+			}
 			pp, err := config.Cloud.Pipelines(config.Ctx, cloud.PipelinesParams{
 				Last:                     &last,
 				RenderWithConfigSections: renderWithConfigSections,
 				CoreInstanceID:           &coreInstanceID,
+				ConfigFormat:             (*cloud.ConfigFormat)(&configFormat),
 			})
 			if err != nil {
 				return fmt.Errorf("could not fetch your pipelines: %w", err)
@@ -88,6 +95,7 @@ func NewCmdGetPipelines(config *cfg.Config) *cobra.Command {
 	fs.BoolVar(&renderWithConfigSections, "render-with-config-sections", false, "Render the pipeline config with the attached config sections; if any")
 	fs.StringVarP(&outputFormat, "output-format", "o", "table", "Output format. Allowed: table, json, yaml, go-template, go-template-file")
 	fs.StringVar(&goTemplate, "template", "", "Template string or path to use when -o=go-template, -o=go-template-file. The template format is golang templates\n[http://golang.org/pkg/text/template/#pkg-overview]")
+	fs.StringVar(&configFormat, "config-format", string(cloud.ConfigFormatYAML), "Format to get the configuration file from the API (yaml/json/ini).")
 
 	_ = cmd.RegisterFlagCompletionFunc("environment", completer.CompleteEnvironments)
 	_ = cmd.RegisterFlagCompletionFunc("output-format", formatters.CompleteOutputFormat)
@@ -104,7 +112,7 @@ func NewCmdGetPipeline(config *cfg.Config) *cobra.Command {
 	var includeEndpoints, includeConfigHistory, includeSecrets bool
 	var showIDs bool
 	var renderWithConfigSections bool
-	var outputFormat, goTemplate string
+	var outputFormat, goTemplate, configFormat string
 	completer := completer.Completer{Config: config}
 
 	cmd := &cobra.Command{
@@ -123,12 +131,20 @@ func NewCmdGetPipeline(config *cfg.Config) *cobra.Command {
 			var ports []cloud.PipelinePort
 			var configHistory []cloud.PipelineConfig
 			var secrets []cloud.PipelineSecret
+
+			if configFormat != "" {
+				if !isValidConfigFormat(configFormat) {
+					return fmt.Errorf("not a valid config format: %s", configFormat)
+				}
+			}
+
 			if outputFormat == "table" && (includeEndpoints || includeConfigHistory || includeSecrets) && !onlyConfig {
 				g, gctx := errgroup.WithContext(config.Ctx)
 				g.Go(func() error {
 					var err error
 					pip, err = config.Cloud.Pipeline(config.Ctx, pipelineID, cloud.PipelineParams{
 						RenderWithConfigSections: renderWithConfigSections,
+						ConfigFormat:             (*cloud.ConfigFormat)(&configFormat),
 					})
 					if err != nil {
 						return fmt.Errorf("could not fetch your pipeline: %w", err)
@@ -181,6 +197,7 @@ func NewCmdGetPipeline(config *cfg.Config) *cobra.Command {
 				var err error
 				pip, err = config.Cloud.Pipeline(config.Ctx, pipelineID, cloud.PipelineParams{
 					RenderWithConfigSections: renderWithConfigSections,
+					ConfigFormat:             (*cloud.ConfigFormat)(&configFormat),
 				})
 				if err != nil {
 					return fmt.Errorf("could not fetch your pipeline: %w", err)
@@ -244,10 +261,25 @@ func NewCmdGetPipeline(config *cfg.Config) *cobra.Command {
 	fs.BoolVar(&renderWithConfigSections, "render-with-config-sections", false, "Render the pipeline config with the attached config sections; if any")
 	fs.StringVarP(&outputFormat, "output-format", "o", "table", "Output format. Allowed: table, json, yaml, go-template, go-template-file")
 	fs.StringVar(&goTemplate, "template", "", "Template string or path to use when -o=go-template, -o=go-template-file. The template format is golang templates\n[http://golang.org/pkg/text/template/#pkg-overview]")
-
+	fs.StringVar(&configFormat, "config-format", string(cloud.ConfigFormatYAML), "Format to get the configuration file from the API (yaml/json/ini).")
 	fs.BoolVar(&showIDs, "show-ids", false, "Include IDs in table output")
 
 	_ = cmd.RegisterFlagCompletionFunc("output-format", formatters.CompleteOutputFormat)
 
 	return cmd
+}
+
+var allValidConfigFormats = []cloud.ConfigFormat{
+	cloud.ConfigFormatYAML,
+	cloud.ConfigFormatJSON,
+	cloud.ConfigFormatINI,
+}
+
+func isValidConfigFormat(s string) bool {
+	for _, val := range allValidConfigFormats {
+		if val == cloud.ConfigFormat(s) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
# Summary of this proposal

Allow to specify the config format for pipeline retrieval.


## Notes for the reviewer

Tested with 

```shell
➜ cli (main) ✗ ./cli get pipeline health-check-c391 --only-config --config-format yaml
service:
    HTTP_Server: "On"
    HTTP_Listen: 0.0.0.0
    HTTP_PORT: 2020
    Log_Level: debug
➜ cli (main) ✗ ./cli get pipeline health-check-c391 --only-config --config-format ini
[SERVICE]
    HTTP_Server  On
    HTTP_Listen  0.0.0.0
    HTTP_PORT    2020
    Log_Level debug
➜ cli (main) ✗ ./cli get pipeline health-check-c391 --only-config --config-format json
{"service":{"HTTP_Server":"On","HTTP_Listen":"0.0.0.0","HTTP_PORT":2020,"Log_Level":"debug"},"pipeline":{}}
➜ cli (main) ✗ ./cli get pipeline health-check-c391 --only-config
service:
    HTTP_Server: "On"
    HTTP_Listen: 0.0.0.0
    HTTP_PORT: 2020
    Log_Level: debug

```



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205524084721051