### PR TITLE
updating core_instance version

### DIFF
--- a/cmd/coreinstance/update_core_instance_operator.go
+++ b/cmd/coreinstance/update_core_instance_operator.go
@@ -94,6 +94,7 @@ func NewCmdUpdateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 				opts.SkipServiceCreation = &skipServiceCreation
 			}
 
+			opts.Version = &newVersion
 			err = config.Cloud.UpdateCoreInstance(config.Ctx, coreInstanceID, opts)
 			if err != nil {
 				return fmt.Errorf("could not update core instance at calyptia cloud: %w", err)


### PR DESCRIPTION
# Summary of this proposal

Updating core instance version when doing `calyptia update core_instance $name --version v2.0.0` 

## Asana task(s) link.

https://app.asana.com/0/1205296321537082/1205561977564981/f

## Notes for the reviewer

```
# calyptia get core_instances 
NAME VERSION ENVIRONMENT PIPELINES TAGS STATUS      AGE
one1 v2.0.3  default     1         test running     18 minutes
one  v2.0.3  default     2         test unreachable 42 minutes
```

```
go run main.go update core_instance operator one1 --version v2.0.0 
```

```
# calyptia get core_instances 
NAME VERSION ENVIRONMENT PIPELINES TAGS STATUS      AGE
one1 v2.0.0  default     1         test running     18 minutes
one  v2.0.0  default     2         test unreachable 42 minutes
```

