### PR TITLE
Fix incompatible rellocations made by upx + selinux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,10 @@ jobs:
       - name: Update the upx version
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
-          curl --silent -L https://github.com/upx/upx/releases/download/v4.1.0/upx-4.1.0-arm64_linux.tar.xz | tar -xJf - upx-4.1.0-arm64_linux/upx -O > upx && sudo mv upx /bin/ && chmod +x /bin/upx
+          curl --silent -L https://github.com/upx/upx/releases/download/v4.1.0/upx-4.1.0-arm64_linux.tar.xz | tar -xJf - upx-4.1.0-arm64_linux/upx -O > upx 
+          sudo mv upx /bin/
+          sudo chmod a+x /bin/upx
+        shell: bash
 
       - name: Run GoReleaser
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
# Summary of this proposal

Upx version 3.95 generates a relocation table that is incompatible with SELinux default policy set on RHEL9.

```
/usr/local/bin/calyptia:     file format elf64-x86-64



ELF headers start
Modified:e_entry: 612AC70,17347F8
Modified:e_shentsize: 00,40
ELF headers end

Segments start
Modified:PT_LOAD:
	Modified:0:
		Modified:p_memsz: 111C74B,38E38B0
		Modified:p_filesz: 111C74B,00
		Modified:p_flags: 05,06
		Modified:p_vaddr: 500F000,1736000
		Modified:p_paddr: 500F000,1736000
Segments end

Blocks start
Different not used blocks:
	First data diff at: 18
	Data sizes: 111C6E0,1335104
	First data diff at: 00
Blocks end
```

With version 4.1.X the binary executes with no problem. With upx disabled the binaries works
correctly across amd64/arm64 on both RHEL8/9 however, upx provides a 4x size reduction that I am
not keen to disable. 

With enabled > 4.1.X also works flawless, so this PR just updates the local version of upx used
as no newer release https://github.com/upx/upx/releases







---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205593504179261