### PR TITLE
Fixing uninstall command

### DIFF
--- a/cmd/operator/uninstall.go
+++ b/cmd/operator/uninstall.go
@@ -66,7 +66,7 @@ func NewCmdUninstall() *cobra.Command {
 }
 
 func prepareUninstallManifest(version string, namespace string) (string, error) {
-	file, err := k8s.GetOperatorManifest(version)
+	file, err := f.ReadFile(manifestFile)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
# Summary of this proposal

Fixed uninstall command

## Asana task(s) link.

https://app.asana.com/0/1204316201844829/1205692588442329/f

## Notes for the reviewer
Install 
```
$ go run main.go install operator
customresourcedefinition.apiextensions.k8s.io/pipelines.core.calyptia.com created
serviceaccount/calyptia-core-controller-manager created
clusterrole.rbac.authorization.k8s.io/calyptia-core-manager-role created
clusterrole.rbac.authorization.k8s.io/calyptia-core-metrics-reader created
clusterrole.rbac.authorization.k8s.io/calyptia-core-pod-role created
clusterrole.rbac.authorization.k8s.io/calyptia-core-proxy-role created
clusterrolebinding.rbac.authorization.k8s.io/calyptia-core-manager-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/calyptia-core-proxy-rolebinding created
service/calyptia-core-controller-manager-metrics-service created
deployment.apps/calyptia-core-controller-manager created
Core operator manager successfully installed.
```

After install check:
```
NAME                          CREATED AT
pipelines.core.calyptia.com   2023-10-16T09:04:00Z
NAME                               SECRETS   AGE
calyptia-core-controller-manager   0         13s
NAME                         CREATED AT
calyptia-core-manager-role   2023-10-16T09:04:00Z
NAME                           CREATED AT
calyptia-core-metrics-reader   2023-10-16T09:04:00Z
NAME                     CREATED AT
calyptia-core-pod-role   2023-10-16T09:04:00Z
NAME                       CREATED AT
calyptia-core-proxy-role   2023-10-16T09:04:00Z
NAME                                ROLE                                     AGE
calyptia-core-manager-rolebinding   ClusterRole/calyptia-core-manager-role   14s
NAME                              ROLE                                   AGE
calyptia-core-proxy-rolebinding   ClusterRole/calyptia-core-proxy-role   14s
NAME                                               TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
calyptia-core-controller-manager-metrics-service   ClusterIP   10.43.13.104   <none>        8443/TCP   14s
NAME                               READY   UP-TO-DATE   AVAILABLE   AGE
calyptia-core-controller-manager   1/1     1            1           14s
```

Uninstall 
```
$ go run main.go uninstall operator 
customresourcedefinition.apiextensions.k8s.io "pipelines.core.calyptia.com" deleted
serviceaccount "calyptia-core-controller-manager" deleted
clusterrole.rbac.authorization.k8s.io "calyptia-core-manager-role" deleted
clusterrole.rbac.authorization.k8s.io "calyptia-core-metrics-reader" deleted
clusterrole.rbac.authorization.k8s.io "calyptia-core-pod-role" deleted
clusterrole.rbac.authorization.k8s.io "calyptia-core-proxy-role" deleted
clusterrolebinding.rbac.authorization.k8s.io "calyptia-core-manager-rolebinding" deleted
clusterrolebinding.rbac.authorization.k8s.io "calyptia-core-proxy-rolebinding" deleted
service "calyptia-core-controller-manager-metrics-service" deleted
deployment.apps "calyptia-core-controller-manager" deleted
Calyptia Operator uninstalled successfully.
```
After uninstall check:
```
Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "pipelines.core.calyptia.com" not found
Error from server (NotFound): serviceaccounts "calyptia-core-controller-manager" not found
Error from server (NotFound): clusterroles.rbac.authorization.k8s.io "calyptia-core-manager-role" not found
Error from server (NotFound): clusterroles.rbac.authorization.k8s.io "calyptia-core-metrics-reader" not found
Error from server (NotFound): clusterroles.rbac.authorization.k8s.io "calyptia-core-pod-role" not found
Error from server (NotFound): clusterroles.rbac.authorization.k8s.io "calyptia-core-proxy-role" not found
Error from server (NotFound): clusterrolebindings.rbac.authorization.k8s.io "calyptia-core-manager-rolebinding" not found
Error from server (NotFound): clusterrolebindings.rbac.authorization.k8s.io "calyptia-core-proxy-rolebinding" not found
Error from server (NotFound): services "calyptia-core-controller-manager-metrics-service" not found
Error from server (NotFound): deployments.apps "calyptia-core-controller-manager" not found
```