### PR TITLE
Not assume -v is required when using update core_instance operator.

### DIFF
--- a/cmd/coreinstance/update_core_instance_operator.go
+++ b/cmd/coreinstance/update_core_instance_operator.go
@@ -38,6 +38,10 @@ func NewCmdUpdateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completer.CompleteCoreInstances,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if newVersion == "" {
+				return nil
+			}
+
 			if !strings.HasPrefix(newVersion, "v") {
 				newVersion = fmt.Sprintf("v%s", newVersion)
 			}

--- a/cmd/operator/update.go
+++ b/cmd/operator/update.go
@@ -32,6 +32,9 @@ func NewCmdUpdate() *cobra.Command {
 		Aliases: []string{"opr"},
 		Short:   "Update core operator",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if coreOperatorVersion == "" {
+				return nil
+			}
 			if !strings.HasPrefix(coreOperatorVersion, "v") {
 				coreOperatorVersion = fmt.Sprintf("v%s", coreOperatorVersion)
 			}
@@ -112,7 +115,7 @@ func NewCmdUpdate() *cobra.Command {
 
 	fs.BoolVar(&waitReady, "wait", false, "Wait for the core instance to be ready before returning")
 	fs.BoolVar(&verbose, "verbose", false, "Print verbose command output")
-	fs.StringVar(&coreOperatorVersion, "version", utils.DefaultCoreOperatorDockerImageTag, "Core instance version")
+	fs.StringVar(&coreOperatorVersion, "version", "", "Core instance version")
 	_ = cmd.Flags().MarkHidden("image")
 	clientcmd.BindOverrideFlags(configOverrides, fs, clientcmd.RecommendedConfigOverrideFlags("kube-"))
 


### PR DESCRIPTION
# Summary of this proposal

Not assume -v is required when using update core_instance operator.

## Asana task(s) link.

<!--- Mandatory: Please provide the related asana task(s) -->

## Notes for the reviewer

Without this patch

```
➜ ~ calyptia update core_instance operator  cl --enable-cluster-logging
Error: core_instance image tag v is not available
```

With this patch:

```
➜ cli (main) ✗ ./cli update core_instance operator cl --enable-cluster-logging
➜ cli (version-update) ✗ kubectl get pods -A  | grep -i cluster-logging
default              cluster-logging-e54b-2hsm-nwlvr                     1/1     Running   0          119s
```
