### PR TITLE
Add http_proxy/https_proxy to create core_instance.

### DIFF
--- a/cmd/coreinstance/create_core_instance_operator.go
+++ b/cmd/coreinstance/create_core_instance_operator.go
@@ -43,6 +43,7 @@ func newCmdCreateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 		waitTimeout                    time.Duration
 		noTLSVerify                    bool
 		metricsPort                    string
+		httpProxy, httpsProxy          string
 	)
 
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
@@ -270,7 +271,7 @@ func newCmdCreateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 				coreDockerFromCloudImage = fmt.Sprintf("%s:%s", utils.DefaultCoreOperatorFromCloudDockerImage, coreDockerFromCloudImageTag)
 			}
 
-			syncDeployment, err := k8sClient.DeployCoreOperatorSync(ctx, coreCloudURL, coreDockerFromCloudImage, coreDockerToCloudImage, metricsPort, !noTLSVerify, created, serviceAccount.Name)
+			syncDeployment, err := k8sClient.DeployCoreOperatorSync(ctx, coreCloudURL, coreDockerFromCloudImage, coreDockerToCloudImage, metricsPort, !noTLSVerify, httpProxy, httpsProxy, created, serviceAccount.Name)
 			if err != nil {
 				fmt.Printf("An error occurred while creating the core operator instance. %s Rolling back created resources.\n", err)
 				resources, err := k8sClient.DeleteResources(ctx, resourcesCreated)
@@ -337,6 +338,9 @@ func newCmdCreateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 	fs.BoolVar(&noTLSVerify, "no-tls-verify", false, "Disable TLS verification when connecting to Calyptia Cloud API.")
 	fs.StringVar(&metricsPort, "metrics-port", "15334", "Port for metrics endpoint.")
 	fs.StringVar(&environment, "environment", "", "Calyptia environment name")
+	fs.StringVar(&httpProxy, "http-proxy", "", "http proxy to use on this core instance")
+	fs.StringVar(&httpsProxy, "https-proxy", "", "http proxy to use on this core instance")
+
 	fs.StringSliceVar(&tags, "tags", nil, "Tags to apply to the core instance")
 
 	clientcmd.BindOverrideFlags(configOverrides, fs, clientcmd.RecommendedConfigOverrideFlags("kube-"))

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -591,7 +591,7 @@ func (client *Client) FindDeploymentByLabel(ctx context.Context, label string) (
 	return client.AppsV1().Deployments(client.Namespace).List(ctx, metav1.ListOptions{LabelSelector: label})
 }
 
-func (client *Client) DeployCoreOperatorSync(ctx context.Context, coreCloudURL, fromCloudImage, toCloudImage string, metricsPort string, noTLSVerify bool, coreInstance cloud.CreatedCoreInstance, serviceAccount string) (*appsv1.Deployment, error) {
+func (client *Client) DeployCoreOperatorSync(ctx context.Context, coreCloudURL, fromCloudImage, toCloudImage string, metricsPort string, noTLSVerify bool, httpProxy, httpsProxy string, coreInstance cloud.CreatedCoreInstance, serviceAccount string) (*appsv1.Deployment, error) {
 	labels := client.LabelsFunc()
 	env := []apiv1.EnvVar{
 		{
@@ -621,6 +621,14 @@ func (client *Client) DeployCoreOperatorSync(ctx context.Context, coreCloudURL, 
 		{
 			Name:  "METRICS_PORT",
 			Value: metricsPort,
+		},
+		{
+			Name:  "HTTP_PROXY",
+			Value: httpProxy,
+		},
+		{
+			Name:  "HTTPS_PROXY",
+			Value: httpsProxy,
 		},
 	}
 	toCloud := apiv1.Container{


### PR DESCRIPTION
# Summary of this proposal

This PR adds the http(s)_proxy variables to
create core_instance operator.


## Notes for the reviewer

```
➜ cli (pass-http-proxy) ✗ ./cli create core_instance operator test --http-proxy=https://localhost:3128    

  lenient-jigsaw-9170-sync-to-cloud:
    Container ID:   containerd://cd15753a465e1784b2592066406c831d05183bf9818fb63f9b9abc4099b30fcb
    Image:          ghcr.io/calyptia/core-operator/sync-to-cloud:v2.0.16
    Image ID:       ghcr.io/calyptia/core-operator/sync-to-cloud@sha256:0732e77b2d7afc3e0a465989f7082f6ad36436bf2d107e0a1e5e9dab94c23f8b
    Port:           <none>
    Host Port:      <none>
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       Error
      Exit Code:    1
      Started:      Mon, 23 Oct 2023 17:44:25 +0200
      Finished:     Mon, 23 Oct 2023 17:44:25 +0200
    Ready:          False
    Restart Count:  1
    Environment:
      CORE_INSTANCE:  lenient-jigsaw-9170
      NAMESPACE:      default
      CLOUD_URL:      https://cloud-api.calyptia.com
      TOKEN:          xxxx.x2DegfVaWCvUvraLJkb1iJ8JFAgueXJxJAdx56amkbwVjTCepPaQdz5FzydXJuW6
      INTERVAL:       15s
      NO_TLS_VERIFY:  true
      METRICS_PORT:   15334
      HTTP_PROXY:     https://localhost:3128
      HTTPS_PROXY:    

```

