### PR TITLE
Switch update to install manifests.

### DIFF
--- a/cmd/operator/install.go
+++ b/cmd/operator/install.go
@@ -52,7 +52,6 @@ func NewCmdInstall() *cobra.Command {
 		Aliases: []string{"opr"},
 		Short:   "Setup a new core operator instance",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			kctl := newKubectlCmd()
 			var namespace string
 
 			kubeNamespaceFlag := cmd.Flag("kube-namespace")
@@ -93,7 +92,8 @@ func NewCmdInstall() *cobra.Command {
 			if !confirmed {
 				isInstalled, err := k.IsOperatorInstalled(cmd.Context())
 				if isInstalled {
-					if e, ok := err.(*k8s.OperatorIncompleteError); ok {
+					var e *k8s.OperatorIncompleteError
+					if errors.As(err, &e) {
 						cmd.Printf("Previous operator installation components found:\n%s\n", e.Error())
 						cmd.Printf("Are you sure you want to proceed? (y/N) ")
 						var answer string
@@ -119,20 +119,13 @@ func NewCmdInstall() *cobra.Command {
 				return err
 			}
 
-			yaml, err := prepareInstallManifest(coreDockerImage, coreInstanceVersion, namespace, k8serrors.IsNotFound(err))
-			defer os.RemoveAll(yaml)
-			if err != nil {
-				return err
-			}
-
-			kctl.SetArgs([]string{"apply", "-f", yaml})
-			err = kctl.Execute()
+			manifest, err := installManifest(namespace, coreDockerImage, coreInstanceVersion, k8serrors.IsNotFound(err))
 			if err != nil {
 				return err
 			}
 
 			if waitReady {
-				deployment, err := extractDeployment(yaml)
+				deployment, err := extractDeployment(manifest)
 				if err != nil {
 					return err
 				}
@@ -296,4 +289,22 @@ func newKubectlCmd() *cobra.Command {
 
 	logs.AddFlags(cmd.PersistentFlags())
 	return cmd
+}
+
+func installManifest(namespace, coreDockerImage, coreInstanceVersion string, createNamespace bool) (string, error) {
+	kctl := newKubectlCmd()
+
+	manifest, err := prepareInstallManifest(coreDockerImage, coreInstanceVersion, namespace, createNamespace)
+	defer os.RemoveAll(manifest)
+	if err != nil {
+		return "", err
+	}
+
+	kctl.SetArgs([]string{"apply", "-f", manifest})
+	err = kctl.Execute()
+	if err != nil {
+		return "", err
+	}
+
+	return manifest, err
 }

--- a/cmd/operator/update.go
+++ b/cmd/operator/update.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -18,6 +19,10 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 
 	"github.com/calyptia/cli/k8s"
+)
+
+const (
+	defaultWaitTimeout = time.Second * 30
 )
 
 func NewCmdUpdate() *cobra.Command {
@@ -99,18 +104,30 @@ func NewCmdUpdate() *cobra.Command {
 				return err
 			}
 
-			label := fmt.Sprintf("%s=%s,%s=%s,%s=%s", k8s.LabelComponent, "manager", k8s.LabelCreatedBy, "operator", k8s.LabelInstance, "controller-manager")
-			cmd.Printf("Waiting for core-operator to update...\n")
-			if err := k.UpdateOperatorDeploymentByLabel(cmd.Context(), label, fmt.Sprintf("%s:%s", utils.DefaultCoreOperatorDockerImage, coreOperatorVersion), verbose, waitTimeout); err != nil {
-				if !verbose {
-					return fmt.Errorf("could not update core-operator to version %s for extra details use --verbose flag", coreOperatorVersion)
-				}
-				return fmt.Errorf("could not update core-operator to version %s, \n%s", coreOperatorVersion, err)
+			if coreOperatorVersion == "" {
+				coreOperatorVersion = utils.DefaultCoreOperatorDockerImageTag
+			}
 
+			manifest, err := installManifest(namespace, utils.DefaultCoreOperatorDockerImage, coreOperatorVersion, k8serrors.IsNotFound(err))
+			if err != nil {
+				return err
+			}
+
+			if waitReady {
+				deployment, err := extractDeployment(manifest)
+				if err != nil {
+					return err
+				}
+				start := time.Now()
+				fmt.Printf("Waiting for core operator manager to be updated...\n")
+				err = k.WaitReady(context.Background(), namespace, deployment, false, waitTimeout)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("Core operator manager is ready. Update took %s\n", time.Since(start))
 			}
 
 			cmd.Printf("Core operator manager successfully updated to version %s\n", coreOperatorVersion)
-
 			return nil
 		},
 	}
@@ -118,7 +135,7 @@ func NewCmdUpdate() *cobra.Command {
 	fs := cmd.Flags()
 
 	fs.BoolVar(&waitReady, "wait", false, "Wait for the core instance to be ready before returning")
-	fs.DurationVar(&waitTimeout, "timeout", time.Second*30, "Wait timeout")
+	fs.DurationVar(&waitTimeout, "timeout", defaultWaitTimeout, "Wait timeout")
 	fs.BoolVar(&verbose, "verbose", false, "Print verbose command output")
 	fs.StringVar(&coreOperatorVersion, "version", "", "Core instance version")
 	_ = cmd.Flags().MarkHidden("image")


### PR DESCRIPTION
# Summary of this proposal

Instead of updating the version of the image
"calyptia update operator" should update the manifest files that will also include the new image versions.

## Notes for the reviewer

```
➜ cli (main) ✗ calyptia install operator --version v2.0.12   
customresourcedefinition.apiextensions.k8s.io/ingestchecks.core.calyptia.com created
customresourcedefinition.apiextensions.k8s.io/pipelines.core.calyptia.com created
serviceaccount/calyptia-core-controller-manager created
clusterrole.rbac.authorization.k8s.io/calyptia-core-manager-role created
clusterrole.rbac.authorization.k8s.io/calyptia-core-metrics-reader created
clusterrole.rbac.authorization.k8s.io/calyptia-core-pod-role created
clusterrole.rbac.authorization.k8s.io/calyptia-core-proxy-role created
clusterrolebinding.rbac.authorization.k8s.io/calyptia-core-manager-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/calyptia-core-proxy-rolebinding created
service/calyptia-core-controller-manager-metrics-service created
deployment.apps/calyptia-core-controller-manager created
Core operator manager successfully installed.


➜ cli (main) ✗ kubectl describe pod calyptia-core-controller-manager-76b77ccdbc-qcmnp | grep -i image
    Image:         ghcr.io/calyptia/core-operator:v2.0.12
    Image ID:      ghcr.io/calyptia/core-operator@sha256:7871356c4891090b9ac016424288af4059086600d488e53516b700dd364798c4
  Normal   Pulling           8s    kubelet            Pulling image "ghcr.io/calyptia/core-operator:v2.0.12"
  Normal   Pulled            5s    kubelet            Successfully pulled image "ghcr.io/calyptia/core-operator:v2.0.12" in 3.415884419s (3.41596146s including waiting)




➜ cli (main) ✗ ./cli update operator --version v2.0.16
customresourcedefinition.apiextensions.k8s.io/ingestchecks.core.calyptia.com configured
customresourcedefinition.apiextensions.k8s.io/pipelines.core.calyptia.com configured
serviceaccount/calyptia-core-controller-manager unchanged
clusterrole.rbac.authorization.k8s.io/calyptia-core-manager-role configured
clusterrole.rbac.authorization.k8s.io/calyptia-core-metrics-reader unchanged
clusterrole.rbac.authorization.k8s.io/calyptia-core-pod-role unchanged
clusterrole.rbac.authorization.k8s.io/calyptia-core-proxy-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/calyptia-core-manager-rolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/calyptia-core-proxy-rolebinding unchanged
service/calyptia-core-controller-manager-metrics-service unchanged
deployment.apps/calyptia-core-controller-manager configured
Core operator manager successfully updated to version v2.0.16


➜ cli (main) ✗ kubectl describe pod calyptia-core-controller-manager-6f48674795-r2hlt | grep -i image
    Image:         ghcr.io/calyptia/core-operator:v2.0.16
    Image ID:      ghcr.io/calyptia/core-operator@sha256:90a83433c9d67b0ba4dc9921dd4b10a110ed8640eac4ef52f127b9ed4194fe45
  Normal  Pulling    26s   kubelet            Pulling image "ghcr.io/calyptia/core-operator:v2.0.16"
  Normal  Pulled     23s   kubelet            Successfully pulled image "ghcr.io/calyptia/core-operator:v2.0.16" in 2.992904835s (2.992914959s including waiting)


➜ cli (main) ✗ ./cli update operator                                                                 
customresourcedefinition.apiextensions.k8s.io/ingestchecks.core.calyptia.com configured
customresourcedefinition.apiextensions.k8s.io/pipelines.core.calyptia.com configured
serviceaccount/calyptia-core-controller-manager unchanged
clusterrole.rbac.authorization.k8s.io/calyptia-core-manager-role configured
clusterrole.rbac.authorization.k8s.io/calyptia-core-metrics-reader unchanged
clusterrole.rbac.authorization.k8s.io/calyptia-core-pod-role unchanged
clusterrole.rbac.authorization.k8s.io/calyptia-core-proxy-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/calyptia-core-manager-rolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/calyptia-core-proxy-rolebinding unchanged
service/calyptia-core-controller-manager-metrics-service unchanged
deployment.apps/calyptia-core-controller-manager configured
Core operator manager successfully updated to version v2.0.17
```

