### PR TITLE
install: update to remove old downloaded binary first

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,8 +57,9 @@ _download_url() {
 
 echo "Downloading Calyptia CLI from URL: $(_download_url)"
 curl --progress-bar --output cli.tar.gz -SLf "$(_download_url)"
+rm -f calyptia
 tar -xzf cli.tar.gz calyptia
-rm cli.tar.gz
+rm -f cli.tar.gz
 
 install_dir=$1
 if [ "$install_dir" != "" ]; then


### PR DESCRIPTION
# Summary of this proposal

Resolves issue with install script when there is a local `calyptia` binary that causes it to fail: this may come about in a myriad of ways including previous failed install script runs.
We remove any local binary prior to attempting to extract it to prevent the failure.

## Asana task(s) link.

https://app.asana.com/0/1205296321537082/1205915665013499/f

## Notes for the reviewer

<!-- Provide any notes that might be important for the (reviewer) of changes -->


