### PR TITLE
Avoid removing manifest file before wait.

### DIFF
--- a/cmd/operator/install.go
+++ b/cmd/operator/install.go
@@ -123,6 +123,7 @@ func NewCmdInstall() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			defer os.RemoveAll(manifest)
 
 			if waitReady {
 				deployment, err := extractDeployment(manifest)
@@ -295,7 +296,6 @@ func installManifest(namespace, coreDockerImage, coreInstanceVersion string, cre
 	kctl := newKubectlCmd()
 
 	manifest, err := prepareInstallManifest(coreDockerImage, coreInstanceVersion, namespace, createNamespace)
-	defer os.RemoveAll(manifest)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/operator/update.go
+++ b/cmd/operator/update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -112,6 +113,8 @@ func NewCmdUpdate() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			defer os.RemoveAll(manifest)
 
 			if waitReady {
 				deployment, err := extractDeployment(manifest)


### PR DESCRIPTION
# Summary of this proposal

If wait is used, then the extractManifest function gets called, which requires the file to exists.
Remove the defer os.Remove from the install method and move to the main method.


## Notes for the reviewer

Without this fix.

```
(env) ➜ cloud (main) ✗ calyptia install operator  --wait
Previous operator installation components found:
CustomResourceDefinition Pipeline installed
Operator pod: default/calyptia-core-controller-manager
ClusterRole: calyptia-core-manager-role
ClusterRole: calyptia-core-metrics-reader
ClusterRole: calyptia-core-pod-role
ClusterRole: calyptia-core-proxy-role
ClusterRoleBinding: calyptia-core-manager-rolebinding
ClusterRoleBinding: calyptia-core-proxy-rolebinding
ServiceAccount: default/calyptia-core-controller-manager
Are you sure you want to proceed? (y/N) y
customresourcedefinition.apiextensions.k8s.io/ingestchecks.core.calyptia.com configured
customresourcedefinition.apiextensions.k8s.io/pipelines.core.calyptia.com configured
serviceaccount/calyptia-core-controller-manager unchanged
clusterrole.rbac.authorization.k8s.io/calyptia-core-manager-role configured
clusterrole.rbac.authorization.k8s.io/calyptia-core-metrics-reader unchanged
clusterrole.rbac.authorization.k8s.io/calyptia-core-pod-role unchanged
clusterrole.rbac.authorization.k8s.io/calyptia-core-proxy-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/calyptia-core-manager-rolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/calyptia-core-proxy-rolebinding unchanged
service/calyptia-core-controller-manager-metrics-service unchanged
deployment.apps/calyptia-core-controller-manager unchanged
Error: open /var/folders/b9/p3lf4v3s3w33m7mr_kzk06rr0000gn/T/calyptia-operator2772250746/operator_2617573803.yaml: no such file or directory
```
With this fix

```
➜ cli (main) ✗ ./cli install operator --wait                                                                                  
Previous operator installation components found:
CustomResourceDefinition Pipeline installed
Operator pod: default/calyptia-core-controller-manager
ClusterRole: calyptia-core-manager-role
ClusterRole: calyptia-core-metrics-reader
ClusterRole: calyptia-core-pod-role
ClusterRole: calyptia-core-proxy-role
ClusterRoleBinding: calyptia-core-manager-rolebinding
ClusterRoleBinding: calyptia-core-proxy-rolebinding
ServiceAccount: default/calyptia-core-controller-manager
Are you sure you want to proceed? (y/N) y
customresourcedefinition.apiextensions.k8s.io/ingestchecks.core.calyptia.com configured
customresourcedefinition.apiextensions.k8s.io/pipelines.core.calyptia.com configured
serviceaccount/calyptia-core-controller-manager unchanged
clusterrole.rbac.authorization.k8s.io/calyptia-core-manager-role configured
clusterrole.rbac.authorization.k8s.io/calyptia-core-metrics-reader unchanged
clusterrole.rbac.authorization.k8s.io/calyptia-core-pod-role unchanged
clusterrole.rbac.authorization.k8s.io/calyptia-core-proxy-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/calyptia-core-manager-rolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/calyptia-core-proxy-rolebinding unchanged
service/calyptia-core-controller-manager-metrics-service unchanged
deployment.apps/calyptia-core-controller-manager unchanged
Waiting for core operator manager to be ready...
Core operator manager is ready. Took 5.323375ms
Core operator manager successfully installed.

```

Pending to add a cloud-e2e test to validate this.