### PR TITLE
create: add extra info to help debug remotely when creating instances

### DIFF
--- a/cmd/coreinstance/create_core_instance_k8s.go
+++ b/cmd/coreinstance/create_core_instance_k8s.go
@@ -74,7 +74,7 @@ func newCmdCreateCoreInstanceOnK8s(config *cfg.Config, testClientSet kubernetes.
 
 			created, err := config.Cloud.CreateCoreInstance(ctx, coreInstanceParams)
 			if err != nil {
-				return fmt.Errorf("could not create core instance at calyptia cloud: %w", err)
+				return fmt.Errorf("could not create core instance (%q) at calyptia cloud (%q): %w", coreInstanceName, coreCloudURL, err)
 			}
 
 			if configOverrides.Context.Namespace == "" {

--- a/cmd/coreinstance/create_core_instance_operator.go
+++ b/cmd/coreinstance/create_core_instance_operator.go
@@ -177,7 +177,7 @@ func newCmdCreateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 
 			created, err := config.Cloud.CreateCoreInstance(ctx, coreInstanceParams)
 			if err != nil {
-				return fmt.Errorf("could not create core instance at calyptia cloud: %w", err)
+				return fmt.Errorf("could not create core instance (%q) at calyptia cloud (%q): %w", coreInstanceName, coreCloudURL, err)
 			}
 
 			labelsFunc := func() map[string]string {


### PR DESCRIPTION
# Summary of this proposal

Adding debug to help diagnose configuration issues when used by customers and in CI.
e.g. https://github.com/calyptia/core-images/actions/runs/6931739258/job/18855427708#step:8:313 just gives us a generic error with no details on what is configured.

```
# Nov 20 15:24:38 core-operator-vm-bats-test bash[2219]: Error: could not create core instance at calyptia cloud: not found
```