### PR TITLE
install: ensure we actually use the passed in version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,8 +48,17 @@ _download_url() {
   # shellcheck disable=SC2154
   _download_version="$cli_VERSION"
 
+  # releases should be prefixed with `v`
+  case "$_download_version" in
+    "latest") ;;
+    "") ;;
+    "v"*) ;;
+    *)
+      _download_version="v$cli_VERSION"
+  esac
+
   if [ -z "$_download_version" ] || [ "$_download_version" = "latest" ]; then
-    if [ -z "$GITHUB_TOKEN" ]; then
+    if [ -n "$GITHUB_TOKEN" ]; then
       _download_version=$(curl --header "Authorization: Bearer $GITHUB_TOKEN" -sSfL https://api.github.com/repos/calyptia/cli/releases/latest 2> /dev/null | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
     else
       _download_version=$(curl -sSfL https://api.github.com/repos/calyptia/cli/releases/latest 2> /dev/null | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')


### PR DESCRIPTION
# Summary of this proposal

Install script never actually uses the passed in `cli_VERSION` value.
Additionally add support for authentication if provided via `GITHUB_TOKEN`.

Tested via:
```shell
$ export cli_VERSION=1.11.0
$ ./install.sh 
Downloading Calyptia CLI from URL: https://github.com/calyptia/cli/releases/download/v1.11.0/cli_1.11.0_linux_amd64.tar.gz
##################################################################################################################################################################################################### 100.0%
Sudo rights are needed to move the binary to /usr/local/bin, please type your password when asked
Calyptia CLI installed in /usr/local/bin/calyptia
$ calyptia version
1.11.0
$ export cli_VERSION=v1.10.1
$ ./install.sh 
Downloading Calyptia CLI from URL: https://github.com/calyptia/cli/releases/download/v1.10.1/cli_1.10.1_linux_amd64.tar.gz
##################################################################################################################################################################################################### 100.0%
Sudo rights are needed to move the binary to /usr/local/bin, please type your password when asked
Calyptia CLI installed in /usr/local/bin/calyptia
$ calyptia version
1.10.1
$ unset cli_VERSION
$ ./install.sh 
Downloading Calyptia CLI from URL: https://github.com/calyptia/cli/releases/download/v1.11.1/cli_1.11.1_linux_amd64.tar.gz
##################################################################################################################################################################################################### 100.0%
Sudo rights are needed to move the binary to /usr/local/bin, please type your password when asked
Calyptia CLI installed in /usr/local/bin/calyptia
$ calyptia version
1.11.1
$ unset GITHUB_TOKEN
$ export cli_VERSION=1.11.0
$ ./install.sh 
Downloading Calyptia CLI from URL: https://github.com/calyptia/cli/releases/download/v1.11.0/cli_1.11.0_linux_amd64.tar.gz
##################################################################################################################################################################################################### 100.0%
Sudo rights are needed to move the binary to /usr/local/bin, please type your password when asked
Calyptia CLI installed in /usr/local/bin/calyptia
$ calyptia version
1.11.0
$ unset cli_VERSION
$ ./install.sh 
Downloading Calyptia CLI from URL: https://github.com/calyptia/cli/releases/download/v1.11.1/cli_1.11.1_linux_amd64.tar.gz
##################################################################################################################################################################################################### 100.0%
Sudo rights are needed to move the binary to /usr/local/bin, please type your password when asked
Calyptia CLI installed in /usr/local/bin/calyptia
$ calyptia version
1.11.1
```
