### PR TITLE
ensure that all calyptia objects are removed from the cluster

### DIFF
--- a/cmd/operator/install.go
+++ b/cmd/operator/install.go
@@ -260,6 +260,9 @@ func addImage(coreDockerImage, coreInstanceVersion, file string) (string, error)
 }
 
 func injectNamespace(s string, namespace string) string {
+	if namespace == "" {
+		namespace = "default"
+	}
 	if _, err := strconv.Atoi(namespace); err == nil {
 		namespace = fmt.Sprintf(`"%s"`, namespace)
 	}


### PR DESCRIPTION
# Summary of this proposal

When uninstall operator is invoked all pipelines, ingestchecks and other potential leftoves will be wiped from the cluster.

## Asana task(s) link.

Loosely related to this: 
https://app.asana.com/0/1204316201844829/1206045382355812

## Notes for the reviewer

You will notice that ClusterRoles, ClusterRoleBindings and ServiceAccount are being removed too. This is because that when the first pipeline is created we create those to ensure that pipelines have minimum required permissions to work in the cluster. https://github.com/calyptia/core-operator/blob/main/pkg/provider/pipeline.go#L466



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206179313345498