### PR TITLE
fix: two consecutive core instance update issue

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -509,12 +509,13 @@ func (client *Client) UpdateSyncDeploymentByLabel(ctx context.Context, label, ne
 		}
 	}
 
+	if deployment.Spec.Template.Annotations == nil {
+        	deployment.Spec.Template.Annotations = make(map[string]string)
+   	}
+    	deployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format("20060102150405")
+
 	_, err = client.AppsV1().Deployments(client.Namespace).Update(ctx, &deployment, metav1.UpdateOptions{})
 	if err != nil {
-		return err
-	}
-
-	if err := client.rolloutDeployment(ctx, deployment.Namespace, deployment.Name); err != nil {
 		return err
 	}
 

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -509,10 +509,12 @@ func (client *Client) UpdateSyncDeploymentByLabel(ctx context.Context, label, ne
 		}
 	}
 
-	if deployment.Spec.Template.Annotations == nil {
-        	deployment.Spec.Template.Annotations = make(map[string]string)
+	annotations := deployment.Spec.Template.Annotations
+	if len(annotations) == 0 {
+        	annotations = make(map[string]string)
    	}
-    	deployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format("20060102150405")
+    	annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format("20060102150405")
+	deployment.Spec.Template.Annotations = annotations
 
 	_, err = client.AppsV1().Deployments(client.Namespace).Update(ctx, &deployment, metav1.UpdateOptions{})
 	if err != nil {


### PR DESCRIPTION
# Summary of this proposal
Fixes two consecutive core instance update issue causes wait to fail removing annotation patch function and integrate it before the update

<!-- Provide summary of changes -->

## Asana task(s) link.

<!--- Mandatory: Please provide the related asana task(s) -->

## Notes for the reviewer

<!-- Provide any notes that might be important for the (reviewer) of changes -->


